### PR TITLE
Change sample rate and depth conversions to use unsigned long longs

### DIFF
--- a/scopehal/PicoOscilloscope.cpp
+++ b/scopehal/PicoOscilloscope.cpp
@@ -578,7 +578,7 @@ vector<uint64_t> PicoOscilloscope::GetSampleRatesNonInterleaved()
 			break;
 
 		auto block = rates.substr(istart, i-istart);
-		auto fs = stoull(block);
+		uint64_t fs = stoull(block);
 		auto hz = FS_PER_SECOND / fs;
 		ret.push_back(hz);
 
@@ -622,7 +622,8 @@ vector<uint64_t> PicoOscilloscope::GetSampleDepthsNonInterleaved()
 		if(i == string::npos)
 			break;
 
-		ret.push_back(stoull(depths.substr(istart, i-istart)));
+		uint64_t sampleDepth = stoull(depths.substr(istart, i-istart))
+		ret.push_back(sampleDepth);
 
 		//skip the comma
 		i++;

--- a/scopehal/PicoOscilloscope.cpp
+++ b/scopehal/PicoOscilloscope.cpp
@@ -578,7 +578,7 @@ vector<uint64_t> PicoOscilloscope::GetSampleRatesNonInterleaved()
 			break;
 
 		auto block = rates.substr(istart, i-istart);
-		auto fs = stol(block);
+		auto fs = stoull(block);
 		auto hz = FS_PER_SECOND / fs;
 		ret.push_back(hz);
 
@@ -622,7 +622,7 @@ vector<uint64_t> PicoOscilloscope::GetSampleDepthsNonInterleaved()
 		if(i == string::npos)
 			break;
 
-		ret.push_back(stol(depths.substr(istart, i-istart)));
+		ret.push_back(stoull(depths.substr(istart, i-istart)));
 
 		//skip the comma
 		i++;


### PR DESCRIPTION
For some godforsaken reason, Windows insists that longs should be 32 bits wide, and Linux (I think) thinks they should be 64 bits wide. I'm currently running the picoscope SCPI bridge in a WSL instance, and glscopeclient on the Windows side. This is introducing crashes, as the picoscope bridge is happy to serialize a long > 32 bits max, but glscopeclient freaks out and crashes since this is above it's perceived max long value. Changing the SCPI parsing functions to use stoull should fix this, since all systems look like they agree that unsigned long long's are 64 bits wide.