### PR TITLE
Add linux-gpib transport

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(SYSTEM ${GTKMM_INCLUDE_DIRS} ${SIGCXX_INCLUDE_DIRS})
 link_directories(${GTKMM_LIBRARY_DIRS} ${SIGCXX_LIBRARY_DIRS})
 
 find_library(LXI_LIB lxi)
+find_library(LINUXGPIB_LIB gpib)
 
 
 # Additional Windows/Linux libraries
@@ -27,6 +28,14 @@ if(LXI_LIB)
 else()
 	set(HAS_LXI false)
 	set(LXI_LIBRARIES "")
+endif()
+
+if(LINUXGPIB_LIB)
+	set(HAS_LINUXGPIB true)
+	set(LINUXGPIB_LIBRARIES ${LINUXGPIB_LIB})
+else()
+	set(HAS_LINUXGPIB false)
+	set(LINUXGPIB_LIBRARIES "")
 endif()
 
 if(OpenCL_FOUND)
@@ -56,6 +65,7 @@ set(SCOPEHAL_SOURCES
 	SCPISocketTransport.cpp
 	SCPITwinLanTransport.cpp
 	VICPSocketTransport.cpp
+	SCPILinuxGPIBTransport.cpp
 	SCPILxiTransport.cpp
 	SCPINullTransport.cpp
 	SCPITMCTransport.cpp
@@ -134,7 +144,7 @@ configure_file(config.h.in config.h)
 add_library(scopehal SHARED
 	${SCOPEHAL_SOURCES})
 target_link_libraries(scopehal ${SIGCXX_LIBRARIES} ${GTKMM_LIBRARIES} xptools log graphwidget ${YAML_LIBRARIES}
-	${LXI_LIBRARIES} ${WIN_LIBS} ${LIN_LIBS} ${LIBFFTS_LIBRARIES} ${OpenCL_LIBRARIES} ${CLFFT_LIBRARIES} ${OpenMP_CXX_LIBRARIES})
+	${LXI_LIBRARIES} ${LINUXGPIB_LIBRARIES} ${WIN_LIBS} ${LIN_LIBS} ${LIBFFTS_LIBRARIES} ${OpenCL_LIBRARIES} ${CLFFT_LIBRARIES} ${OpenMP_CXX_LIBRARIES})
 
 target_include_directories(scopehal
 PUBLIC
@@ -152,6 +162,10 @@ PUBLIC SYSTEM
 
 if(${HAS_LXI})
 	target_compile_definitions(scopehal PUBLIC HAS_LXI)
+endif()
+
+if(${HAS_LINUXGPIB})
+	target_compile_definitions(scopehal PUBLIC HAS_LINUXGPIB)
 endif()
 
 install(TARGETS scopehal LIBRARY)

--- a/scopehal/SCPILinuxGPIBTransport.cpp
+++ b/scopehal/SCPILinuxGPIBTransport.cpp
@@ -1,0 +1,163 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2022 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@author Mike Walters
+	@brief Implementation of SCPILinuxGPIBTransport
+ */
+
+#ifdef HAS_LINUXGPIB
+
+#include <stdio.h>
+#include <stdlib.h>
+//#include <string.h>
+
+#include "scopehal.h"
+
+#include <gpib/ib.h>
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+SCPILinuxGPIBTransport::SCPILinuxGPIBTransport(const string& args)
+	: m_devicePath(args)
+{
+	auto result = sscanf(args.c_str(), "%d:%d:%d:%d", &m_board_index, &m_pad, &m_sad, &m_timeout);
+	if (result < 2) {
+		LogError("Invalid device string, must specify at least board index and primary address");
+		return;
+	}
+
+	LogDebug("Connecting to SCPI oscilloscope over GPIB%d with address %d:%d\n",
+		m_board_index,
+		m_pad,
+		m_sad
+	);
+
+	m_handle = ibdev(m_board_index, m_pad, m_sad, m_timeout, 0, 0);
+	if (m_handle < 0)
+	{
+		LogError("Couldn't open %s\n", m_devicePath.c_str());
+		return;
+	}
+}
+
+SCPILinuxGPIBTransport::~SCPILinuxGPIBTransport()
+{
+	if (IsConnected())
+		ibonl(m_handle, 0);
+
+}
+
+bool SCPILinuxGPIBTransport::IsConnected()
+{
+	return (m_handle >= 0);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Actual transport code
+
+string SCPILinuxGPIBTransport::GetTransportName()
+{
+	return "gpib";
+}
+
+string SCPILinuxGPIBTransport::GetConnectionString()
+{
+	return m_devicePath;
+}
+
+void SCPILinuxGPIBTransport::FlushRXBuffer()
+{
+	if (!IsConnected())
+		return;
+
+	unsigned char buf[1024];
+	ibclr(m_handle);
+	while (ReadRawData(1024, buf) != 0) {}
+}
+
+bool SCPILinuxGPIBTransport::SendCommand(const string& cmd)
+{
+	if (!IsConnected())
+		return false;
+
+	LogTrace("Sending %s\n", cmd.c_str());
+	string tempbuf = cmd + "\n";
+	ibwrt(m_handle, tempbuf.c_str(), tempbuf.length());
+	return (ibcnt == (int)tempbuf.length());
+}
+
+string SCPILinuxGPIBTransport::ReadReply(bool endOnSemicolon)
+{
+	string ret;
+	if (!IsConnected())
+		return ret;
+
+	char buf[1024];
+	while(true)
+	{
+		ibrd(m_handle, buf, 1024);
+		LogTrace("Got %d\n", ibcnt);
+		ret.append(buf, ibcnt);
+		if (ret.back() == '\n' || (endOnSemicolon && (ret.back() == ';'))) {
+			ret.pop_back();
+			break;
+		}
+	}
+	LogTrace("Got %s\n", ret.c_str());
+	return ret;
+}
+
+void SCPILinuxGPIBTransport::SendRawData(size_t len, const unsigned char* buf)
+{
+	if (!IsConnected())
+		return;
+
+	ibwrt(m_handle, (const char *)buf, len);
+}
+
+size_t SCPILinuxGPIBTransport::ReadRawData(size_t len, unsigned char* buf)
+{
+	if (!IsConnected())
+		return 0;
+
+	ibrd(m_handle, buf, len);
+	return ibcnt;
+}
+
+bool SCPILinuxGPIBTransport::IsCommandBatchingSupported()
+{
+	return false;
+}
+
+#endif

--- a/scopehal/SCPILinuxGPIBTransport.h
+++ b/scopehal/SCPILinuxGPIBTransport.h
@@ -1,0 +1,79 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2022 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+/**
+	@file
+	@author Mike Walters
+	@brief Declaration of SCPILinuxGPIBTransport
+ */
+
+#ifdef HAS_LINUXGPIB
+
+#ifndef SCPILinuxGPIBTransport_h
+#define SCPILinuxGPIBTransport_h
+
+/**
+	@brief Abstraction of a transport layer for moving SCPI data between endpoints
+ */
+class SCPILinuxGPIBTransport : public SCPITransport
+{
+public:
+	SCPILinuxGPIBTransport(const std::string& args);
+	~SCPILinuxGPIBTransport();
+
+	//not copyable or assignable
+	SCPILinuxGPIBTransport(const SCPILinuxGPIBTransport&) =delete;
+	SCPILinuxGPIBTransport& operator=(const SCPILinuxGPIBTransport&) =delete;
+
+	std::string GetConnectionString() override;
+	static std::string GetTransportName();
+
+	void FlushRXBuffer(void) override;
+	bool SendCommand(const std::string& cmd) override;
+	std::string ReadReply(bool endOnSemicolon = true) override;
+	size_t ReadRawData(size_t len, unsigned char* buf) override;
+	void SendRawData(size_t len, const unsigned char* buf) override;
+
+	bool IsCommandBatchingSupported() override;
+	bool IsConnected() override;
+
+	TRANSPORT_INITPROC(SCPILinuxGPIBTransport)
+
+protected:
+	std::string m_devicePath;
+
+	int m_handle = -1;
+	int m_board_index;
+	int m_pad;
+	int m_sad = 0;
+	int m_timeout = 10;
+};
+
+#endif
+
+#endif

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -112,6 +112,9 @@ void TransportStaticInit()
 #ifdef HAS_LXI
 	AddTransportClass(SCPILxiTransport);
 #endif
+#ifdef HAS_LINUXGPIB
+	AddTransportClass(SCPILinuxGPIBTransport);
+#endif
 }
 
 /**

--- a/scopehal/scopehal.h
+++ b/scopehal/scopehal.h
@@ -75,6 +75,7 @@
 #include "SCPITransport.h"
 #include "SCPISocketTransport.h"
 #include "SCPITwinLanTransport.h"
+#include "SCPILinuxGPIBTransport.h"
 #include "SCPILxiTransport.h"
 #include "SCPINullTransport.h"
 #include "SCPITMCTransport.h"


### PR DESCRIPTION
This adds support for using [linux-gpib](https://linux-gpib.sourceforge.io/) as SCPI transport. It'll be compiled in if `libgpib` can be found, similar to the current behaviour for LXI support.

I've tested with an Agilent 82357A USB/GPIB adapter and an MSO6034A using the `agilent` driver:

![scopehal-gpib](https://user-images.githubusercontent.com/578095/183259846-8e03e288-8ad7-4018-bb26-b5bcd87d3041.png)


closes #574