### PR TITLE
Refactor GetText/GetColor to be properties on protocol waveforms

### DIFF
--- a/scopeexports/CSVExportWizard.cpp
+++ b/scopeexports/CSVExportWizard.cpp
@@ -340,8 +340,7 @@ void CSVExportWizard::on_apply()
 
 			case Stream::STREAM_TYPE_PROTOCOL:
 				{
-					auto reffilt = dynamic_cast<Filter*>(streams[0].m_channel);
-					fprintf(fp, ",%s", reffilt->GetText(i, streams[0].m_stream).c_str());
+					fprintf(fp, ",%s", timebaseWaveform->GetText(i).c_str());
 				}
 				break;
 
@@ -415,9 +414,8 @@ void CSVExportWizard::on_apply()
 				//First-hit "interpolation"
 				case Stream::STREAM_TYPE_PROTOCOL:
 					{
-						auto filt = dynamic_cast<Filter*>(streams[j].m_channel);
 						if(firstHit)
-							fprintf(fp, ",%s", filt->GetText(k, streams[i].m_stream).c_str());
+							fprintf(fp, ",%s", w->GetText(k).c_str());
 						else
 							fprintf(fp, ",");
 					}

--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -127,7 +127,7 @@ set(SCOPEHAL_SOURCES
 	RohdeSchwarzHMC8012Multimeter.cpp
 	RohdeSchwarzHMC804xPowerSupply.cpp
 
-	Waveform.cpp
+	StandardColors.cpp
 	Filter.cpp
 	FilterParameter.cpp
 	ImportFilter.cpp

--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -127,6 +127,7 @@ set(SCOPEHAL_SOURCES
 	RohdeSchwarzHMC8012Multimeter.cpp
 	RohdeSchwarzHMC804xPowerSupply.cpp
 
+	Waveform.cpp
 	Filter.cpp
 	FilterParameter.cpp
 	ImportFilter.cpp

--- a/scopehal/Filter.cpp
+++ b/scopehal/Filter.cpp
@@ -47,18 +47,6 @@ map<pair<WaveformBase*, float>, vector<int64_t> > Filter::m_zeroCrossingCache;
 
 map<string, unsigned int> Filter::m_instanceCount;
 
-Gdk::Color Filter::m_standardColors[STANDARD_COLOR_COUNT] =
-{
-	Gdk::Color("#336699"),	//COLOR_DATA
-	Gdk::Color("#c000a0"),	//COLOR_CONTROL
-	Gdk::Color("#ffff00"),	//COLOR_ADDRESS
-	Gdk::Color("#808080"),	//COLOR_PREAMBLE
-	Gdk::Color("#00ff00"),	//COLOR_CHECKSUM_OK
-	Gdk::Color("#ff0000"),	//COLOR_CHECKSUM_BAD
-	Gdk::Color("#ff0000"),	//COLOR_ERROR
-	Gdk::Color("#404040")	//COLOR_IDLE
-};
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Construction / destruction
 
@@ -1081,41 +1069,6 @@ void Filter::LoadParameters(const YAML::Node& node, IDTable& table)
 				SetOffset(snode["offset"].as<float>(), index);
 		}
 	}
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Complex protocol decodes
-
-Gdk::Color Filter::GetColor(size_t /*i*/, size_t /*stream*/)
-{
-	return m_standardColors[COLOR_ERROR];
-}
-
-string Filter::GetText(size_t /*i*/, size_t /*stream*/)
-{
-	return "(unimplemented)";
-}
-
-string Filter::GetTextForAsciiChannel(int i, size_t stream)
-{
-	AsciiWaveform* capture = dynamic_cast<AsciiWaveform*>(GetData(stream));
-	if(capture != NULL)
-	{
-		char c = capture->m_samples[i];
-		char sbuf[16] = {0};
-		if(isprint(c))
-			sbuf[0] = c;
-		else if(c == '\r')		//special case common non-printable chars
-			return "\\r";
-		else if(c == '\n')
-			return "\\n";
-		else if(c == '\b')
-			return "\\b";
-		else
-			snprintf(sbuf, sizeof(sbuf), "\\x%02x", 0xFF & c);
-		return sbuf;
-	}
-	return "";
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/scopehal/Filter.h
+++ b/scopehal/Filter.h
@@ -242,10 +242,6 @@ protected:
 	DigitalWaveform* SetupDigitalOutputWaveform(WaveformBase* din, size_t stream, size_t skipstart, size_t skipend);
 
 public:
-	// //Text formatting for CHANNEL_TYPE_COMPLEX decodes
-	// virtual Gdk::Color GetColor(size_t i, size_t stream);
-	// virtual std::string GetText(size_t i, size_t stream);
-
 	//Helpers for sub-sample interoplation
 	static float InterpolateTime(AnalogWaveform* cap, size_t a, float voltage);
 	static float InterpolateTime(AnalogWaveform* p, AnalogWaveform* n, size_t a, float voltage);

--- a/scopehal/Filter.h
+++ b/scopehal/Filter.h
@@ -213,30 +213,6 @@ public:
 
 	virtual void LoadParameters(const YAML::Node& node, IDTable& table);
 
-	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-	// Color table (TODO: probably should be refactored)
-
-	/**
-		@brief Standard colors for protocol decode overlays.
-
-		Do not change ordering, add new items to the end only.
-	 */
-	enum FilterColor
-	{
-		COLOR_DATA,			//protocol data
-		COLOR_CONTROL,		//generic control sequences
-		COLOR_ADDRESS,		//addresses or device IDs
-		COLOR_PREAMBLE,		//preambles, start bits, and other constant framing
-		COLOR_CHECKSUM_OK,	//valid CRC/checksum
-		COLOR_CHECKSUM_BAD,	//invalid CRC/checksum
-		COLOR_ERROR,		//malformed traffic
-		COLOR_IDLE,			//downtime between frames
-
-		STANDARD_COLOR_COUNT
-	};
-
-	static Gdk::Color m_standardColors[STANDARD_COLOR_COUNT];
-
 protected:
 
 	///Group used for the display menu
@@ -266,9 +242,9 @@ protected:
 	DigitalWaveform* SetupDigitalOutputWaveform(WaveformBase* din, size_t stream, size_t skipstart, size_t skipend);
 
 public:
-	//Text formatting for CHANNEL_TYPE_COMPLEX decodes
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
+	// //Text formatting for CHANNEL_TYPE_COMPLEX decodes
+	// virtual Gdk::Color GetColor(size_t i, size_t stream);
+	// virtual std::string GetText(size_t i, size_t stream);
 
 	//Helpers for sub-sample interoplation
 	static float InterpolateTime(AnalogWaveform* cap, size_t a, float voltage);
@@ -330,8 +306,6 @@ protected:
 	unsigned int m_instanceNum;
 
 protected:
-	//Common text formatting
-	virtual std::string GetTextForAsciiChannel(int i, size_t stream);
 
 #ifdef HAVE_OPENCL
 

--- a/scopehal/StandardColors.cpp
+++ b/scopehal/StandardColors.cpp
@@ -1,0 +1,45 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal                                                                                                          *
+*                                                                                                                      *
+* Copyright (c) 2012-2022 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+#include "StandardColors.h"
+
+namespace StandardColors
+{
+	Gdk::Color colors[StandardColors::STANDARD_COLOR_COUNT] =
+	{
+		Gdk::Color("#336699"),	//COLOR_DATA
+		Gdk::Color("#c000a0"),	//COLOR_CONTROL
+		Gdk::Color("#ffff00"),	//COLOR_ADDRESS
+		Gdk::Color("#808080"),	//COLOR_PREAMBLE
+		Gdk::Color("#00ff00"),	//COLOR_CHECKSUM_OK
+		Gdk::Color("#ff0000"),	//COLOR_CHECKSUM_BAD
+		Gdk::Color("#ff0000"),	//COLOR_ERROR
+		Gdk::Color("#404040")	//COLOR_IDLE
+	};
+}

--- a/scopehal/StandardColors.h
+++ b/scopehal/StandardColors.h
@@ -30,7 +30,9 @@
 #ifndef StandardColors_h
 #define StandardColors_h
 
-#include "../scopehal/scopehal.h"
+#include <gtkmm.h>
+
+// TODO: This doesn't seem like it belongs in scopehal
 
 namespace StandardColors
 {

--- a/scopehal/StandardColors.h
+++ b/scopehal/StandardColors.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
 *                                                                                                                      *
-* libscopeprotocols                                                                                                    *
+* libscopehal v0.1                                                                                                     *
 *                                                                                                                      *
 * Copyright (c) 2012-2022 Andrew D. Zonenberg and contributors                                                         *
 * All rights reserved.                                                                                                 *
@@ -27,20 +27,28 @@
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
+#ifndef StandardColors_h
+#define StandardColors_h
+
 #include "../scopehal/scopehal.h"
-#include "Waveform.h"
 
 namespace StandardColors
 {
-	Gdk::Color colors[StandardColors::STANDARD_COLOR_COUNT] =
+	enum FilterColor
 	{
-		Gdk::Color("#336699"),	//COLOR_DATA
-		Gdk::Color("#c000a0"),	//COLOR_CONTROL
-		Gdk::Color("#ffff00"),	//COLOR_ADDRESS
-		Gdk::Color("#808080"),	//COLOR_PREAMBLE
-		Gdk::Color("#00ff00"),	//COLOR_CHECKSUM_OK
-		Gdk::Color("#ff0000"),	//COLOR_CHECKSUM_BAD
-		Gdk::Color("#ff0000"),	//COLOR_ERROR
-		Gdk::Color("#404040")	//COLOR_IDLE
+		COLOR_DATA,			//protocol data
+		COLOR_CONTROL,		//generic control sequences
+		COLOR_ADDRESS,		//addresses or device IDs
+		COLOR_PREAMBLE,		//preambles, start bits, and other constant framing
+		COLOR_CHECKSUM_OK,	//valid CRC/checksum
+		COLOR_CHECKSUM_BAD,	//invalid CRC/checksum
+		COLOR_ERROR,		//malformed traffic
+		COLOR_IDLE,			//downtime between frames
+
+		STANDARD_COLOR_COUNT
 	};
+
+	extern Gdk::Color colors[STANDARD_COLOR_COUNT];
 }
+
+#endif // StandardColors_h

--- a/scopehal/Waveform.cpp
+++ b/scopehal/Waveform.cpp
@@ -27,74 +27,20 @@
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
-/**
-	@file
-	@author Andrew D. Zonenberg
-	@brief Declaration of I2CEepromDecoder
- */
-#ifndef I2CEepromDecoder_h
-#define I2CEepromDecoder_h
+#include "../scopehal/scopehal.h"
+#include "Waveform.h"
 
-#include "../scopehal/PacketDecoder.h"
-
-class I2CEepromSymbol
+namespace StandardColors
 {
-public:
-
-	enum EepromType
+	Gdk::Color colors[StandardColors::STANDARD_COLOR_COUNT] =
 	{
-		TYPE_SELECT_READ,		//select with read bit, ack'd
-		TYPE_SELECT_WRITE,		//select with write bit, ack'd
-		TYPE_POLL_BUSY,			//select with read or write bit, nak'd
-		TYPE_POLL_OK,			//poll success
-		TYPE_ADDRESS,
-		TYPE_DATA
+		Gdk::Color("#336699"),	//COLOR_DATA
+		Gdk::Color("#c000a0"),	//COLOR_CONTROL
+		Gdk::Color("#ffff00"),	//COLOR_ADDRESS
+		Gdk::Color("#808080"),	//COLOR_PREAMBLE
+		Gdk::Color("#00ff00"),	//COLOR_CHECKSUM_OK
+		Gdk::Color("#ff0000"),	//COLOR_CHECKSUM_BAD
+		Gdk::Color("#ff0000"),	//COLOR_ERROR
+		Gdk::Color("#404040")	//COLOR_IDLE
 	};
-
-	I2CEepromSymbol()
-	{}
-
-	I2CEepromSymbol(EepromType type, uint32_t data)
-	 : m_type(type)
-	 , m_data(data)
-	{}
-
-	EepromType m_type;
-	uint32_t m_data;
-
-	bool operator== (const I2CEepromSymbol& s) const
-	{
-		return (m_type == s.m_type) && (m_data == s.m_data);
-	}
-};
-
-typedef Waveform<I2CEepromSymbol> I2CEepromWaveform;
-
-class I2CEepromDecoder : public PacketDecoder
-{
-public:
-	I2CEepromDecoder(const std::string& color);
-
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
-	virtual void Refresh();
-
-	static std::string GetProtocolName();
-
-	std::vector<std::string> GetHeaders();
-
-	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
-
-	bool CanMerge(Packet* first, Packet* cur, Packet* next);
-	Packet* CreateMergedHeader(Packet* pack, size_t i);
-
-	PROTOCOL_DECODER_INITPROC(I2CEepromDecoder)
-
-protected:
-	std::string m_memtypename;
-	std::string m_baseaddrname;
-	std::string m_addrpinname;
-};
-
-#endif
+}

--- a/scopehal/Waveform.h
+++ b/scopehal/Waveform.h
@@ -39,6 +39,8 @@
 #include <vector>
 #include <AlignedAllocator.h>
 
+#include "StandardColors.h"
+
 /**
 	@brief Wrapper around a primitive data type that has an empty default constructor.
 
@@ -67,25 +69,6 @@ public:
 
 	T m_value;
 };
-
-namespace StandardColors
-{
-	enum FilterColor
-	{
-		COLOR_DATA,			//protocol data
-		COLOR_CONTROL,		//generic control sequences
-		COLOR_ADDRESS,		//addresses or device IDs
-		COLOR_PREAMBLE,		//preambles, start bits, and other constant framing
-		COLOR_CHECKSUM_OK,	//valid CRC/checksum
-		COLOR_CHECKSUM_BAD,	//invalid CRC/checksum
-		COLOR_ERROR,		//malformed traffic
-		COLOR_IDLE,			//downtime between frames
-
-		STANDARD_COLOR_COUNT
-	};
-
-	extern Gdk::Color colors[STANDARD_COLOR_COUNT];
-}
 
 /**
 	@brief Base class for all Waveform specializations

--- a/scopehal/Waveform.h
+++ b/scopehal/Waveform.h
@@ -68,6 +68,25 @@ public:
 	T m_value;
 };
 
+namespace StandardColors
+{
+	enum FilterColor
+	{
+		COLOR_DATA,			//protocol data
+		COLOR_CONTROL,		//generic control sequences
+		COLOR_ADDRESS,		//addresses or device IDs
+		COLOR_PREAMBLE,		//preambles, start bits, and other constant framing
+		COLOR_CHECKSUM_OK,	//valid CRC/checksum
+		COLOR_CHECKSUM_BAD,	//invalid CRC/checksum
+		COLOR_ERROR,		//malformed traffic
+		COLOR_IDLE,			//downtime between frames
+
+		STANDARD_COLOR_COUNT
+	};
+
+	extern Gdk::Color colors[STANDARD_COLOR_COUNT];
+}
+
 /**
 	@brief Base class for all Waveform specializations
 
@@ -174,6 +193,16 @@ public:
 		m_durations.resize(size);
 	}
 
+	virtual std::string GetText(size_t /*i*/)
+	{
+		return "(unimplemented)";
+	}
+
+	virtual Gdk::Color GetColor(size_t /*i*/)
+	{
+		return StandardColors::colors[StandardColors::COLOR_ERROR]; 
+	}
+
 	/**
 		@brief Copies offsets/durations from one waveform to another.
 
@@ -217,6 +246,5 @@ typedef Waveform<EmptyConstructorWrapper<bool> >	DigitalWaveform;
 typedef Waveform<EmptyConstructorWrapper<float>>	AnalogWaveform;
 
 typedef Waveform< std::vector<bool> > 	DigitalBusWaveform;
-typedef Waveform<char>					AsciiWaveform;
 
 #endif

--- a/scopeprotocols/ADL5205Decoder.cpp
+++ b/scopeprotocols/ADL5205Decoder.cpp
@@ -85,7 +85,7 @@ void ADL5205Decoder::Refresh()
 	size_t len = din->m_samples.size();
 
 	//Loop over the SPI events and process stuff
-	auto cap = new ADL5205Waveform;
+	auto cap = new ADL5205Waveform(m_displaycolor);
 	cap->m_timescale = din->m_timescale;
 	cap->m_startTimestamp = din->m_startTimestamp;
 	cap->m_startFemtoseconds = din->m_startFemtoseconds;
@@ -154,23 +154,18 @@ void ADL5205Decoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color ADL5205Decoder::GetColor(size_t /*i*/, size_t /*stream*/)
+Gdk::Color ADL5205Waveform::GetColor(size_t /*i*/)
 {
-	return Gdk::Color(m_displaycolor);
+	return Gdk::Color(m_color);
 }
 
-string ADL5205Decoder::GetText(size_t i, size_t /*stream*/)
+string ADL5205Waveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<ADL5205Waveform*>(GetData(0));
-	if(capture != NULL)
-	{
-		const ADL5205Symbol& s = capture->m_samples[i];
+	const ADL5205Symbol& s = m_samples[i];
 
-		char tmp[128];
-		snprintf(tmp, sizeof(tmp), "%s: FA=%d dB, gain=%d dB",
-			s.m_write ? "write" : "read", s.m_fa, s.m_gain);
-		return string(tmp);
-	}
-	return "";
+	char tmp[128];
+	snprintf(tmp, sizeof(tmp), "%s: FA=%d dB, gain=%d dB",
+		s.m_write ? "write" : "read", s.m_fa, s.m_gain);
+	return string(tmp);
 }
 

--- a/scopeprotocols/ADL5205Decoder.h
+++ b/scopeprotocols/ADL5205Decoder.h
@@ -62,9 +62,6 @@ class ADL5205Decoder : public Filter
 public:
 	ADL5205Decoder(const std::string& color);
 
-	virtual std::string GetText(size_t i, size_t stream);
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/ADL5205Decoder.h
+++ b/scopeprotocols/ADL5205Decoder.h
@@ -55,7 +55,16 @@ public:
 	}
 };
 
-typedef Waveform<ADL5205Symbol> ADL5205Waveform;
+class ADL5205Waveform : public Waveform<ADL5205Symbol>
+{
+public:
+	ADL5205Waveform (const std::string& color) : Waveform<ADL5205Symbol>(), m_color(color) {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+
+private:
+	const std::string& m_color;
+};
 
 class ADL5205Decoder : public Filter
 {

--- a/scopeprotocols/CANDecoder.cpp
+++ b/scopeprotocols/CANDecoder.cpp
@@ -539,54 +539,54 @@ Gdk::Color CANDecoder::GetColor(size_t i, size_t /*stream*/)
 		switch(s.m_stype)
 		{
 			case CANSymbol::TYPE_SOF:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case CANSymbol::TYPE_R0:
 				if(!s.m_data)
-					return m_standardColors[COLOR_PREAMBLE];
+					return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 				else
-					return m_standardColors[COLOR_ERROR];
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 			case CANSymbol::TYPE_ID:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case CANSymbol::TYPE_RTR:
 			case CANSymbol::TYPE_FD:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case CANSymbol::TYPE_DLC:
 				if(s.m_data > 8)
-					return m_standardColors[COLOR_ERROR];
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
 				else
-					return m_standardColors[COLOR_CONTROL];
+					return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case CANSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case CANSymbol::TYPE_CRC_OK:
-				return m_standardColors[COLOR_CHECKSUM_OK];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 			case CANSymbol::TYPE_CRC_DELIM:
 			case CANSymbol::TYPE_ACK_DELIM:
 			case CANSymbol::TYPE_EOF:
 				if(s.m_data)
-					return m_standardColors[COLOR_PREAMBLE];
+					return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 				else
-					return m_standardColors[COLOR_ERROR];
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 			case CANSymbol::TYPE_ACK:
 				if(!s.m_data)
-					return m_standardColors[COLOR_CHECKSUM_OK];
+					return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 				else
-					return m_standardColors[COLOR_CHECKSUM_BAD];
+					return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
 
 			case CANSymbol::TYPE_CRC_BAD:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string CANDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/CANDecoder.h
+++ b/scopeprotocols/CANDecoder.h
@@ -83,9 +83,6 @@ class CANDecoder : public PacketDecoder
 public:
 	CANDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/CANDecoder.h
+++ b/scopeprotocols/CANDecoder.h
@@ -76,7 +76,13 @@ public:
 	}
 };
 
-typedef Waveform<CANSymbol> CANWaveform;
+class CANWaveform : public Waveform<CANSymbol>
+{
+public:
+	CANWaveform () : Waveform<CANSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class CANDecoder : public PacketDecoder
 {

--- a/scopeprotocols/DPhyDataDecoder.cpp
+++ b/scopeprotocols/DPhyDataDecoder.cpp
@@ -367,60 +367,47 @@ void DPhyDataDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color DPhyDataDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color DPhyDataWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<DPhyDataWaveform*>(GetData(0));
-	if(capture != NULL)
+	const DPhyDataSymbol& s = m_samples[i];
+
+	switch(s.m_type)
 	{
-		const DPhyDataSymbol& s = capture->m_samples[i];
+		case DPhyDataSymbol::TYPE_SOT:
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
-		switch(s.m_type)
-		{
-			case DPhyDataSymbol::TYPE_SOT:
-				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
+		case DPhyDataSymbol::TYPE_EOT:
+			return StandardColors::colors[StandardColors::COLOR_IDLE];
 
-			case DPhyDataSymbol::TYPE_EOT:
-				return StandardColors::colors[StandardColors::COLOR_IDLE];
+		case DPhyDataSymbol::TYPE_HS_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-			case DPhyDataSymbol::TYPE_HS_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
-
-			case DPhyDataSymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case DPhyDataSymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string DPhyDataDecoder::GetText(size_t i, size_t /*stream*/)
+string DPhyDataWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<DPhyDataWaveform*>(GetData(0));
 	char tmp[32];
+	const DPhyDataSymbol& s = m_samples[i];
 
-	if(capture != NULL)
+	switch(s.m_type)
 	{
-		const DPhyDataSymbol& s = capture->m_samples[i];
+		case DPhyDataSymbol::TYPE_SOT:
+			return "SOT";
 
-		switch(s.m_type)
-		{
-			case DPhyDataSymbol::TYPE_SOT:
-				return "SOT";
+		case DPhyDataSymbol::TYPE_EOT:
+			return "EOT";
 
-			case DPhyDataSymbol::TYPE_EOT:
-				return "EOT";
+		case DPhyDataSymbol::TYPE_HS_DATA:
+			snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			return tmp;
 
-			case DPhyDataSymbol::TYPE_HS_DATA:
-				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				return tmp;
-
-			case DPhyDataSymbol::TYPE_ERROR:
-			default:
-				return "ERROR";
-		}
+		case DPhyDataSymbol::TYPE_ERROR:
+		default:
+			return "ERROR";
 	}
-
-	return "ERROR";
 }
 

--- a/scopeprotocols/DPhyDataDecoder.cpp
+++ b/scopeprotocols/DPhyDataDecoder.cpp
@@ -377,21 +377,21 @@ Gdk::Color DPhyDataDecoder::GetColor(size_t i, size_t /*stream*/)
 		switch(s.m_type)
 		{
 			case DPhyDataSymbol::TYPE_SOT:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case DPhyDataSymbol::TYPE_EOT:
-				return m_standardColors[COLOR_IDLE];
+				return StandardColors::colors[StandardColors::COLOR_IDLE];
 
 			case DPhyDataSymbol::TYPE_HS_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case DPhyDataSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string DPhyDataDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/DPhyDataDecoder.h
+++ b/scopeprotocols/DPhyDataDecoder.h
@@ -68,9 +68,6 @@ class DPhyDataDecoder : public Filter
 public:
 	DPhyDataDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/DPhyDataDecoder.h
+++ b/scopeprotocols/DPhyDataDecoder.h
@@ -61,7 +61,13 @@ public:
 	}
 };
 
-typedef Waveform<DPhyDataSymbol> DPhyDataWaveform;
+class DPhyDataWaveform : public Waveform<DPhyDataSymbol>
+{
+public:
+	DPhyDataWaveform () : Waveform<DPhyDataSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class DPhyDataDecoder : public Filter
 {

--- a/scopeprotocols/DPhyEscapeModeDecoder.cpp
+++ b/scopeprotocols/DPhyEscapeModeDecoder.cpp
@@ -318,21 +318,21 @@ Gdk::Color DPhyEscapeModeDecoder::GetColor(size_t i, size_t /*stream*/)
 		switch(s.m_type)
 		{
 			case DPhyEscapeModeSymbol::TYPE_ESCAPE_ENTRY:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case DPhyEscapeModeSymbol::TYPE_ENTRY_COMMAND:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case DPhyEscapeModeSymbol::TYPE_ESCAPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case DPhyEscapeModeSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string DPhyEscapeModeDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/DPhyEscapeModeDecoder.h
+++ b/scopeprotocols/DPhyEscapeModeDecoder.h
@@ -69,9 +69,6 @@ class DPhyEscapeModeDecoder : public PacketDecoder
 public:
 	DPhyEscapeModeDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	std::vector<std::string> GetHeaders();
 
 	virtual void Refresh();

--- a/scopeprotocols/DPhyEscapeModeDecoder.h
+++ b/scopeprotocols/DPhyEscapeModeDecoder.h
@@ -62,7 +62,13 @@ public:
 	}
 };
 
-typedef Waveform<DPhyEscapeModeSymbol> DPhyEscapeModeWaveform;
+class DPhyEscapeModeWaveform : public Waveform<DPhyEscapeModeSymbol>
+{
+public:
+	DPhyEscapeModeWaveform () : Waveform<DPhyEscapeModeSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class DPhyEscapeModeDecoder : public PacketDecoder
 {

--- a/scopeprotocols/DPhySymbolDecoder.cpp
+++ b/scopeprotocols/DPhySymbolDecoder.cpp
@@ -320,17 +320,17 @@ Gdk::Color DPhySymbolDecoder::GetColor(size_t i, size_t /*stream*/)
 		{
 			case DPhySymbol::STATE_HS0:
 			case DPhySymbol::STATE_HS1:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case DPhySymbol::STATE_LP00:
 			case DPhySymbol::STATE_LP11:
 			case DPhySymbol::STATE_LP01:
 			case DPhySymbol::STATE_LP10:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string DPhySymbolDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/DPhySymbolDecoder.cpp
+++ b/scopeprotocols/DPhySymbolDecoder.cpp
@@ -309,57 +309,52 @@ void DPhySymbolDecoder::Refresh()
 }
 
 
-Gdk::Color DPhySymbolDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color DPhySymbolWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<DPhySymbolWaveform*>(GetData(0));
-	if(capture != NULL)
+	const DPhySymbol& s = m_samples[i];
+
+	switch(s.m_type)
 	{
-		const DPhySymbol& s = capture->m_samples[i];
+		case DPhySymbol::STATE_HS0:
+		case DPhySymbol::STATE_HS1:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-		switch(s.m_type)
-		{
-			case DPhySymbol::STATE_HS0:
-			case DPhySymbol::STATE_HS1:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
+		case DPhySymbol::STATE_LP00:
+		case DPhySymbol::STATE_LP11:
+		case DPhySymbol::STATE_LP01:
+		case DPhySymbol::STATE_LP10:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case DPhySymbol::STATE_LP00:
-			case DPhySymbol::STATE_LP11:
-			case DPhySymbol::STATE_LP01:
-			case DPhySymbol::STATE_LP10:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
-		}
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string DPhySymbolDecoder::GetText(size_t i, size_t /*stream*/)
+string DPhySymbolWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<DPhySymbolWaveform*>(GetData(0));
-	if(capture != NULL)
+	const DPhySymbol& s = m_samples[i];
+
+	switch(s.m_type)
 	{
-		const DPhySymbol& s = capture->m_samples[i];
+		case DPhySymbol::STATE_HS0:
+			return "HS-0";
 
-		switch(s.m_type)
-		{
-			case DPhySymbol::STATE_HS0:
-				return "HS-0";
+		case DPhySymbol::STATE_HS1:
+			return "HS-1";
 
-			case DPhySymbol::STATE_HS1:
-				return "HS-1";
+		case DPhySymbol::STATE_LP00:
+			return "LP-00";
 
-			case DPhySymbol::STATE_LP00:
-				return "LP-00";
+		case DPhySymbol::STATE_LP11:
+			return "LP-11";
 
-			case DPhySymbol::STATE_LP11:
-				return "LP-11";
+		case DPhySymbol::STATE_LP01:
+			return "LP-01";
 
-			case DPhySymbol::STATE_LP01:
-				return "LP-01";
+		case DPhySymbol::STATE_LP10:
+			return "LP-10";
 
-			case DPhySymbol::STATE_LP10:
-				return "LP-10";
-		}
+		default:
+			return "";
 	}
-	return "Unknown";
 }

--- a/scopeprotocols/DPhySymbolDecoder.h
+++ b/scopeprotocols/DPhySymbolDecoder.h
@@ -63,7 +63,13 @@ public:
 	}
 };
 
-typedef Waveform<DPhySymbol> DPhySymbolWaveform;
+class DPhySymbolWaveform : public Waveform<DPhySymbol>
+{
+public:
+	DPhySymbolWaveform () : Waveform<DPhySymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 /**
 	@brief Decoder for MIPI D-PHY symbols.

--- a/scopeprotocols/DPhySymbolDecoder.h
+++ b/scopeprotocols/DPhySymbolDecoder.h
@@ -79,9 +79,6 @@ public:
 
 	static std::string GetProtocolName();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
 
 	PROTOCOL_DECODER_INITPROC(DPhySymbolDecoder)

--- a/scopeprotocols/DSIFrameDecoder.cpp
+++ b/scopeprotocols/DSIFrameDecoder.cpp
@@ -289,7 +289,7 @@ Gdk::Color DSIFrameDecoder::GetColor(size_t i, size_t /*stream*/)
 		{
 			case DSIFrameSymbol::TYPE_HSYNC:
 			case DSIFrameSymbol::TYPE_VSYNC:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case DSIFrameSymbol::TYPE_VIDEO:
 				{
@@ -300,12 +300,12 @@ Gdk::Color DSIFrameDecoder::GetColor(size_t i, size_t /*stream*/)
 
 			case DSIFrameSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
 	//error
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string DSIFrameDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/DSIFrameDecoder.cpp
+++ b/scopeprotocols/DSIFrameDecoder.cpp
@@ -279,60 +279,48 @@ void DSIFrameDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color DSIFrameDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color DSIFrameWaveform::GetColor(size_t i)
 {
-	DSIFrameWaveform* capture = dynamic_cast<DSIFrameWaveform*>(GetData(0));
-	if(capture != NULL)
+	auto s = m_samples[i];
+	switch(s.m_type)
 	{
-		auto s = capture->m_samples[i];
-		switch(s.m_type)
-		{
-			case DSIFrameSymbol::TYPE_HSYNC:
-			case DSIFrameSymbol::TYPE_VSYNC:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+		case DSIFrameSymbol::TYPE_HSYNC:
+		case DSIFrameSymbol::TYPE_VSYNC:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case DSIFrameSymbol::TYPE_VIDEO:
-				{
-					Gdk::Color ret;
-					ret.set_rgb_p(s.m_red / 255.0f, s.m_green / 255.0f, s.m_blue / 255.0f);
-					return ret;
-				}
+		case DSIFrameSymbol::TYPE_VIDEO:
+			{
+				Gdk::Color ret;
+				ret.set_rgb_p(s.m_red / 255.0f, s.m_green / 255.0f, s.m_blue / 255.0f);
+				return ret;
+			}
 
-			case DSIFrameSymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case DSIFrameSymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	//error
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string DSIFrameDecoder::GetText(size_t i, size_t /*stream*/)
+string DSIFrameWaveform::GetText(size_t i)
 {
-	DSIFrameWaveform* capture = dynamic_cast<DSIFrameWaveform*>(GetData(0));
-	if(capture != NULL)
+	auto s = m_samples[i];
+	char tmp[32];
+	switch(s.m_type)
 	{
-		auto s = capture->m_samples[i];
-		char tmp[32];
-		switch(s.m_type)
-		{
-			case DSIFrameSymbol::TYPE_HSYNC:
-				return "HSYNC";
+		case DSIFrameSymbol::TYPE_HSYNC:
+			return "HSYNC";
 
-			case DSIFrameSymbol::TYPE_VSYNC:
-				return "VSYNC";
+		case DSIFrameSymbol::TYPE_VSYNC:
+			return "VSYNC";
 
-			case DSIFrameSymbol::TYPE_VIDEO:
-				snprintf(tmp, sizeof(tmp), "#%02x%02x%02x", s.m_red, s.m_green, s.m_blue);
-				break;
+		case DSIFrameSymbol::TYPE_VIDEO:
+			snprintf(tmp, sizeof(tmp), "#%02x%02x%02x", s.m_red, s.m_green, s.m_blue);
+			break;
 
-			case DSIFrameSymbol::TYPE_ERROR:
-			default:
-				return "ERROR";
+		case DSIFrameSymbol::TYPE_ERROR:
+		default:
+			return "ERROR";
 
-		}
-		return string(tmp);
 	}
-	return "";
+	return string(tmp);
 }

--- a/scopeprotocols/DSIFrameDecoder.h
+++ b/scopeprotocols/DSIFrameDecoder.h
@@ -71,7 +71,13 @@ public:
 	}
 };
 
-typedef Waveform<DSIFrameSymbol> DSIFrameWaveform;
+class DSIFrameWaveform : public Waveform<DSIFrameSymbol>
+{
+public:
+	DSIFrameWaveform () : Waveform<DSIFrameSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class DSIFrameDecoder : public PacketDecoder
 {

--- a/scopeprotocols/DSIFrameDecoder.h
+++ b/scopeprotocols/DSIFrameDecoder.h
@@ -78,9 +78,6 @@ class DSIFrameDecoder : public PacketDecoder
 public:
 	DSIFrameDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/DSIPacketDecoder.cpp
+++ b/scopeprotocols/DSIPacketDecoder.cpp
@@ -203,7 +203,7 @@ void DSIPacketDecoder::Refresh()
 					pack->m_offset = off * din->m_timescale;
 					pack->m_len = 0;
 					pack->m_headers["VC"] = to_string(current_vc);
-					pack->m_headers["Type"] = GetText(cap->m_offsets.size() - 1, 0);
+					pack->m_headers["Type"] = cap->GetText(cap->m_offsets.size() - 1);
 					m_packets.push_back(pack);
 
 					//Set the color for the packet
@@ -503,120 +503,109 @@ void DSIPacketDecoder::Refresh()
 	}
 }
 
-Gdk::Color DSIPacketDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color DSIWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<DSIWaveform*>(GetData(0));
-	if(capture != NULL)
+	const DSISymbol& s = m_samples[i];
+	switch(s.m_stype)
 	{
-		const DSISymbol& s = capture->m_samples[i];
-		switch(s.m_stype)
-		{
-			case DSISymbol::TYPE_VC:
-			case DSISymbol::TYPE_IDENTIFIER:
-				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
+		case DSISymbol::TYPE_VC:
+		case DSISymbol::TYPE_IDENTIFIER:
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
-			case DSISymbol::TYPE_LEN:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+		case DSISymbol::TYPE_LEN:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case DSISymbol::TYPE_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
+		case DSISymbol::TYPE_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-			case DSISymbol::TYPE_ECC_OK:
-			case DSISymbol::TYPE_CHECKSUM_OK:
-				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
+		case DSISymbol::TYPE_ECC_OK:
+		case DSISymbol::TYPE_CHECKSUM_OK:
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
-			case DSISymbol::TYPE_ECC_BAD:
-			case DSISymbol::TYPE_CHECKSUM_BAD:
-			case DSISymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case DSISymbol::TYPE_ECC_BAD:
+		case DSISymbol::TYPE_CHECKSUM_BAD:
+		case DSISymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string DSIPacketDecoder::GetText(size_t i, size_t /*stream*/)
+string DSIWaveform::GetText(size_t i)
 {
 	char tmp[128] = "";
-	auto capture = dynamic_cast<DSIWaveform*>(GetData(0));
-	if(capture != NULL)
+	const DSISymbol& s = m_samples[i];
+	switch(s.m_stype)
 	{
-		const DSISymbol& s = capture->m_samples[i];
-		switch(s.m_stype)
-		{
-			case DSISymbol::TYPE_VC:
-				snprintf(tmp, sizeof(tmp), "VC%d", s.m_data >> 6);
-				return tmp;
+		case DSISymbol::TYPE_VC:
+			snprintf(tmp, sizeof(tmp), "VC%d", s.m_data >> 6);
+			return tmp;
 
-			case DSISymbol::TYPE_IDENTIFIER:
-				switch(s.m_data & 0x3f)
-				{
-					case TYPE_VSYNC_START:	return "VSYNC Start";
-					case TYPE_VSYNC_END:	return "VSYNC End";
-					case TYPE_HSYNC_START:	return "HSYNC Start";
-					case TYPE_HSYNC_END:	return "HSYNC End";
-					case TYPE_EOTP:			return "End of TX";
-					case TYPE_CM_OFF:		return "CM Off";
-					case TYPE_CM_ON:		return "CM On";
-					case TYPE_SHUT_DOWN:	return "Shut Down";
-					case TYPE_TURN_ON:		return "Turn On";
+		case DSISymbol::TYPE_IDENTIFIER:
+			switch(s.m_data & 0x3f)
+			{
+				case DSIPacketDecoder::TYPE_VSYNC_START:	return "VSYNC Start";
+				case DSIPacketDecoder::TYPE_VSYNC_END:		return "VSYNC End";
+				case DSIPacketDecoder::TYPE_HSYNC_START:	return "HSYNC Start";
+				case DSIPacketDecoder::TYPE_HSYNC_END:		return "HSYNC End";
+				case DSIPacketDecoder::TYPE_EOTP:			return "End of TX";
+				case DSIPacketDecoder::TYPE_CM_OFF:			return "CM Off";
+				case DSIPacketDecoder::TYPE_CM_ON:			return "CM On";
+				case DSIPacketDecoder::TYPE_SHUT_DOWN:		return "Shut Down";
+				case DSIPacketDecoder::TYPE_TURN_ON:		return "Turn On";
 
-					case TYPE_GENERIC_SHORT_WRITE_0PARAM:
-					case TYPE_GENERIC_SHORT_WRITE_1PARAM:
-					case TYPE_GENERIC_SHORT_WRITE_2PARAM:
-					case TYPE_GENERIC_LONG_WRITE:
-						return "Generic Write";
+				case DSIPacketDecoder::TYPE_GENERIC_SHORT_WRITE_0PARAM:
+				case DSIPacketDecoder::TYPE_GENERIC_SHORT_WRITE_1PARAM:
+				case DSIPacketDecoder::TYPE_GENERIC_SHORT_WRITE_2PARAM:
+				case DSIPacketDecoder::TYPE_GENERIC_LONG_WRITE:
+					return "Generic Write";
 
-					case TYPE_GENERIC_READ_0PARAM:
-					case TYPE_GENERIC_READ_1PARAM:
-					case TYPE_GENERIC_READ_2PARAM:
-						return "Generic Read";
+				case DSIPacketDecoder::TYPE_GENERIC_READ_0PARAM:
+				case DSIPacketDecoder::TYPE_GENERIC_READ_1PARAM:
+				case DSIPacketDecoder::TYPE_GENERIC_READ_2PARAM:
+					return "Generic Read";
 
-					case TYPE_DCS_SHORT_WRITE_0PARAM:
-					case TYPE_DCS_SHORT_WRITE_1PARAM:
-					case TYPE_DCS_LONG_WRITE:
-						return "DCS Write";
+				case DSIPacketDecoder::TYPE_DCS_SHORT_WRITE_0PARAM:
+				case DSIPacketDecoder::TYPE_DCS_SHORT_WRITE_1PARAM:
+				case DSIPacketDecoder::TYPE_DCS_LONG_WRITE:
+					return "DCS Write";
 
-					case TYPE_DCS_READ:				return "DCS Read";
-					case TYPE_SET_MAX_RETURN_SIZE:	return "Set Max Return Size";
-					case TYPE_NULL:					return "Null";
-					case TYPE_BLANKING:				return "Blank";
-					case TYPE_PACKED_PIXEL_RGB565:	return "RGB565";
-					case TYPE_PACKED_PIXEL_RGB666:	return "RGB666";
-					case TYPE_LOOSE_PIXEL_RGB666:	return "RGB666 Loose";
-					case TYPE_PACKED_PIXEL_RGB888:	return "RGB888";
+				case DSIPacketDecoder::TYPE_DCS_READ:				return "DCS Read";
+				case DSIPacketDecoder::TYPE_SET_MAX_RETURN_SIZE:	return "Set Max Return Size";
+				case DSIPacketDecoder::TYPE_NULL:					return "Null";
+				case DSIPacketDecoder::TYPE_BLANKING:				return "Blank";
+				case DSIPacketDecoder::TYPE_PACKED_PIXEL_RGB565:	return "RGB565";
+				case DSIPacketDecoder::TYPE_PACKED_PIXEL_RGB666:	return "RGB666";
+				case DSIPacketDecoder::TYPE_LOOSE_PIXEL_RGB666:		return "RGB666 Loose";
+				case DSIPacketDecoder::TYPE_PACKED_PIXEL_RGB888:	return "RGB888";
 
-					default:
-						snprintf(tmp, sizeof(tmp), "RSVD %02x", s.m_data & 0x3f);
-						return tmp;
-				}
-				break;
+				default:
+					snprintf(tmp, sizeof(tmp), "RSVD %02x", s.m_data & 0x3f);
+					return tmp;
+			}
+			break;
 
-			case DSISymbol::TYPE_LEN:
-				snprintf(tmp, sizeof(tmp), "Len %d", s.m_data);
-				return tmp;
+		case DSISymbol::TYPE_LEN:
+			snprintf(tmp, sizeof(tmp), "Len %d", s.m_data);
+			return tmp;
 
-			case DSISymbol::TYPE_DATA:
-				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				return tmp;
+		case DSISymbol::TYPE_DATA:
+			snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			return tmp;
 
-			case DSISymbol::TYPE_ECC_OK:
-			case DSISymbol::TYPE_ECC_BAD:
-				snprintf(tmp, sizeof(tmp), "ECC %02x", s.m_data);
-				return tmp;
+		case DSISymbol::TYPE_ECC_OK:
+		case DSISymbol::TYPE_ECC_BAD:
+			snprintf(tmp, sizeof(tmp), "ECC %02x", s.m_data);
+			return tmp;
 
-			case DSISymbol::TYPE_CHECKSUM_OK:
-			case DSISymbol::TYPE_CHECKSUM_BAD:
-				snprintf(tmp, sizeof(tmp), "Check %04x", s.m_data);
-				return tmp;
+		case DSISymbol::TYPE_CHECKSUM_OK:
+		case DSISymbol::TYPE_CHECKSUM_BAD:
+			snprintf(tmp, sizeof(tmp), "Check %04x", s.m_data);
+			return tmp;
 
-			case DSISymbol::TYPE_ERROR:
-			default:
-				return "ERROR";
-		}
+		case DSISymbol::TYPE_ERROR:
+		default:
+			return "ERROR";
 	}
-	return "";
 }
 
 uint16_t DSIPacketDecoder::UpdateCRC(uint16_t crc, uint8_t data)

--- a/scopeprotocols/DSIPacketDecoder.cpp
+++ b/scopeprotocols/DSIPacketDecoder.cpp
@@ -513,27 +513,27 @@ Gdk::Color DSIPacketDecoder::GetColor(size_t i, size_t /*stream*/)
 		{
 			case DSISymbol::TYPE_VC:
 			case DSISymbol::TYPE_IDENTIFIER:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case DSISymbol::TYPE_LEN:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case DSISymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case DSISymbol::TYPE_ECC_OK:
 			case DSISymbol::TYPE_CHECKSUM_OK:
-				return m_standardColors[COLOR_CHECKSUM_OK];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 			case DSISymbol::TYPE_ECC_BAD:
 			case DSISymbol::TYPE_CHECKSUM_BAD:
 			case DSISymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string DSIPacketDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/DSIPacketDecoder.h
+++ b/scopeprotocols/DSIPacketDecoder.h
@@ -77,9 +77,6 @@ class DSIPacketDecoder : public PacketDecoder
 public:
 	DSIPacketDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/DSIPacketDecoder.h
+++ b/scopeprotocols/DSIPacketDecoder.h
@@ -67,7 +67,13 @@ public:
 	}
 };
 
-typedef Waveform<DSISymbol> DSIWaveform;
+class DSIWaveform : public Waveform<DSISymbol>
+{
+public:
+	DSIWaveform () : Waveform<DSISymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 /**
 	@brief Decodes MIPI DSI from a D-PHY data stream

--- a/scopeprotocols/DVIDecoder.cpp
+++ b/scopeprotocols/DVIDecoder.cpp
@@ -279,11 +279,11 @@ Gdk::Color DVIDecoder::GetColor(size_t i, size_t /*stream*/)
 		switch(s.m_type)
 		{
 			case DVISymbol::DVI_TYPE_PREAMBLE:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case DVISymbol::DVI_TYPE_HSYNC:
 			case DVISymbol::DVI_TYPE_VSYNC:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case DVISymbol::DVI_TYPE_VIDEO:
 				{
@@ -294,12 +294,12 @@ Gdk::Color DVIDecoder::GetColor(size_t i, size_t /*stream*/)
 
 			case DVISymbol::DVI_TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
 	//error
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string DVIDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/DVIDecoder.cpp
+++ b/scopeprotocols/DVIDecoder.cpp
@@ -270,66 +270,54 @@ void DVIDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color DVIDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color DVIWaveform::GetColor(size_t i)
 {
-	DVIWaveform* capture = dynamic_cast<DVIWaveform*>(GetData(0));
-	if(capture != NULL)
+	auto s = m_samples[i];
+	switch(s.m_type)
 	{
-		auto s = capture->m_samples[i];
-		switch(s.m_type)
-		{
-			case DVISymbol::DVI_TYPE_PREAMBLE:
-				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
+		case DVISymbol::DVI_TYPE_PREAMBLE:
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
-			case DVISymbol::DVI_TYPE_HSYNC:
-			case DVISymbol::DVI_TYPE_VSYNC:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+		case DVISymbol::DVI_TYPE_HSYNC:
+		case DVISymbol::DVI_TYPE_VSYNC:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case DVISymbol::DVI_TYPE_VIDEO:
-				{
-					Gdk::Color ret;
-					ret.set_rgb_p(s.m_red / 255.0f, s.m_green / 255.0f, s.m_blue / 255.0f);
-					return ret;
-				}
+		case DVISymbol::DVI_TYPE_VIDEO:
+			{
+				Gdk::Color ret;
+				ret.set_rgb_p(s.m_red / 255.0f, s.m_green / 255.0f, s.m_blue / 255.0f);
+				return ret;
+			}
 
-			case DVISymbol::DVI_TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case DVISymbol::DVI_TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	//error
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string DVIDecoder::GetText(size_t i, size_t /*stream*/)
+string DVIWaveform::GetText(size_t i)
 {
-	DVIWaveform* capture = dynamic_cast<DVIWaveform*>(GetData(0));
-	if(capture != NULL)
+	auto s = m_samples[i];
+	char tmp[32];
+	switch(s.m_type)
 	{
-		auto s = capture->m_samples[i];
-		char tmp[32];
-		switch(s.m_type)
-		{
-			case DVISymbol::DVI_TYPE_PREAMBLE:
-				return "BLANK";
+		case DVISymbol::DVI_TYPE_PREAMBLE:
+			return "BLANK";
 
-			case DVISymbol::DVI_TYPE_HSYNC:
-				return "HSYNC";
+		case DVISymbol::DVI_TYPE_HSYNC:
+			return "HSYNC";
 
-			case DVISymbol::DVI_TYPE_VSYNC:
-				return "VSYNC";
+		case DVISymbol::DVI_TYPE_VSYNC:
+			return "VSYNC";
 
-			case DVISymbol::DVI_TYPE_VIDEO:
-				snprintf(tmp, sizeof(tmp), "#%02x%02x%02x", s.m_red, s.m_green, s.m_blue);
-				break;
+		case DVISymbol::DVI_TYPE_VIDEO:
+			snprintf(tmp, sizeof(tmp), "#%02x%02x%02x", s.m_red, s.m_green, s.m_blue);
+			break;
 
-			case DVISymbol::DVI_TYPE_ERROR:
-			default:
-				return "ERROR";
+		case DVISymbol::DVI_TYPE_ERROR:
+		default:
+			return "ERROR";
 
-		}
-		return string(tmp);
 	}
-	return "";
+	return string(tmp);
 }

--- a/scopeprotocols/DVIDecoder.h
+++ b/scopeprotocols/DVIDecoder.h
@@ -85,9 +85,6 @@ class DVIDecoder : public PacketDecoder
 public:
 	DVIDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/DVIDecoder.h
+++ b/scopeprotocols/DVIDecoder.h
@@ -78,7 +78,13 @@ public:
 	virtual ~VideoScanlinePacket();
 };
 
-typedef Waveform<DVISymbol> DVIWaveform;
+class DVIWaveform : public Waveform<DVISymbol>
+{
+public:
+	DVIWaveform () : Waveform<DVISymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class DVIDecoder : public PacketDecoder
 {

--- a/scopeprotocols/ESPIDecoder.cpp
+++ b/scopeprotocols/ESPIDecoder.cpp
@@ -1402,10 +1402,10 @@ Gdk::Color ESPIDecoder::GetColor(size_t i, size_t /*stream*/)
 			case ESPISymbol::TYPE_RESPONSE_STATUS:
 			case ESPISymbol::TYPE_FLASH_REQUEST_TYPE:
 			case ESPISymbol::TYPE_REQUEST_LEN:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case ESPISymbol::TYPE_WAIT:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case ESPISymbol::TYPE_CAPS_ADDR:
 			case ESPISymbol::TYPE_VWIRE_COUNT:
@@ -1414,14 +1414,14 @@ Gdk::Color ESPIDecoder::GetColor(size_t i, size_t /*stream*/)
 			case ESPISymbol::TYPE_FLASH_REQUEST_ADDR:
 			case ESPISymbol::TYPE_SMBUS_REQUEST_ADDR:
 			case ESPISymbol::TYPE_IO_ADDR:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case ESPISymbol::TYPE_COMMAND_CRC_GOOD:
 			case ESPISymbol::TYPE_RESPONSE_CRC_GOOD:
-				return m_standardColors[COLOR_CHECKSUM_OK];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 			case ESPISymbol::TYPE_COMMAND_CRC_BAD:
 			case ESPISymbol::TYPE_RESPONSE_CRC_BAD:
-				return m_standardColors[COLOR_CHECKSUM_BAD];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
 
 			case ESPISymbol::TYPE_GENERAL_CAPS:
 			case ESPISymbol::TYPE_CH0_CAPS_RD:
@@ -1437,13 +1437,13 @@ Gdk::Color ESPIDecoder::GetColor(size_t i, size_t /*stream*/)
 			case ESPISymbol::TYPE_SMBUS_REQUEST_DATA:
 			case ESPISymbol::TYPE_IO_DATA:
 			case ESPISymbol::TYPE_COMPLETION_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case ESPISymbol::TYPE_SMBUS_REQUEST_TYPE:
 				if(s.m_data == ESPISymbol::CYCLE_SMBUS)
-					return m_standardColors[COLOR_CONTROL];
+					return StandardColors::colors[StandardColors::COLOR_CONTROL];
 				else
-					return m_standardColors[COLOR_ERROR];
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 			case ESPISymbol::TYPE_COMPLETION_TYPE:
 				switch(s.m_data)
@@ -1453,21 +1453,21 @@ Gdk::Color ESPIDecoder::GetColor(size_t i, size_t /*stream*/)
 					case ESPISymbol::CYCLE_SUCCESS_DATA_FIRST:
 					case ESPISymbol::CYCLE_SUCCESS_DATA_LAST:
 					case ESPISymbol::CYCLE_SUCCESS_DATA_ONLY:
-						return m_standardColors[COLOR_CONTROL];
+						return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 					case ESPISymbol::CYCLE_FAIL_LAST:
 					case ESPISymbol::CYCLE_FAIL_ONLY:
 					default:
-						return m_standardColors[COLOR_ERROR];
+						return StandardColors::colors[StandardColors::COLOR_ERROR];
 				};
 				break;
 
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string ESPIDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/ESPIDecoder.cpp
+++ b/scopeprotocols/ESPIDecoder.cpp
@@ -375,7 +375,7 @@ void ESPIDecoder::Refresh()
 					cap->m_offsets.push_back(bytestart);
 					cap->m_durations.push_back(timestamp - bytestart);
 					cap->m_samples.push_back(ESPISymbol(ESPISymbol::TYPE_COMMAND_TYPE, current_byte));
-					pack->m_headers["Command"] = GetText(cap->m_samples.size()-1, 0);
+					pack->m_headers["Command"] = cap->GetText(cap->m_samples.size()-1);
 
 					//Decide what to do based on the opcode
 					count = 0;
@@ -526,7 +526,7 @@ void ESPIDecoder::Refresh()
 					{
 						cap->m_durations.push_back(timestamp - tstart);
 						cap->m_samples.push_back(ESPISymbol(ESPISymbol::TYPE_CAPS_ADDR, addr));
-						pack->m_headers["Address"] = GetText(cap->m_samples.size()-1, 0);
+						pack->m_headers["Address"] = cap->GetText(cap->m_samples.size()-1);
 
 						if(current_cmd == ESPISymbol::COMMAND_SET_CONFIGURATION)
 						{
@@ -566,17 +566,17 @@ void ESPIDecoder::Refresh()
 								{
 									case 0x10:
 										cap->m_samples.push_back(ESPISymbol(ESPISymbol::TYPE_CH0_CAPS_WR, data));
-										pack->m_headers["Info"] = Trim(GetText(cap->m_samples.size()-1, 0));
+										pack->m_headers["Info"] = Trim(cap->GetText(cap->m_samples.size()-1));
 										break;
 
 									case 0x20:
 										cap->m_samples.push_back(ESPISymbol(ESPISymbol::TYPE_CH1_CAPS_WR, data));
-										pack->m_headers["Info"] = Trim(GetText(cap->m_samples.size()-1, 0));
+										pack->m_headers["Info"] = Trim(cap->GetText(cap->m_samples.size()-1));
 										break;
 
 									case 0x30:
 										cap->m_samples.push_back(ESPISymbol(ESPISymbol::TYPE_CH2_CAPS_WR, data));
-										pack->m_headers["Info"] = Trim(GetText(cap->m_samples.size()-1, 0));
+										pack->m_headers["Info"] = Trim(cap->GetText(cap->m_samples.size()-1));
 										break;
 
 									default:
@@ -627,7 +627,7 @@ void ESPIDecoder::Refresh()
 						if(completion_type != ESPISymbol::COMPLETION_NONE)
 							LogWarning("Appended completions not implemented yet\n");
 
-						pack->m_headers["Response"] = GetText(cap->m_samples.size()-1, 0);
+						pack->m_headers["Response"] = cap->GetText(cap->m_samples.size()-1);
 
 						count = 0;
 						data = 0;
@@ -689,22 +689,22 @@ void ESPIDecoder::Refresh()
 								{
 									case 0x8:
 										cap->m_samples.push_back(ESPISymbol(ESPISymbol::TYPE_GENERAL_CAPS, data));
-										pack->m_headers["Info"] = Trim(GetText(cap->m_samples.size()-1, 0));
+										pack->m_headers["Info"] = Trim(cap->GetText(cap->m_samples.size()-1));
 										break;
 
 									case 0x10:
 										cap->m_samples.push_back(ESPISymbol(ESPISymbol::TYPE_CH0_CAPS_RD, data));
-										pack->m_headers["Info"] = Trim(GetText(cap->m_samples.size()-1, 0));
+										pack->m_headers["Info"] = Trim(cap->GetText(cap->m_samples.size()-1));
 										break;
 
 									case 0x20:
 										cap->m_samples.push_back(ESPISymbol(ESPISymbol::TYPE_CH1_CAPS_RD, data));
-										pack->m_headers["Info"] = Trim(GetText(cap->m_samples.size()-1, 0));
+										pack->m_headers["Info"] = Trim(cap->GetText(cap->m_samples.size()-1));
 										break;
 
 									case 0x30:
 										cap->m_samples.push_back(ESPISymbol(ESPISymbol::TYPE_CH2_CAPS_RD, data));
-										pack->m_headers["Info"] = Trim(GetText(cap->m_samples.size()-1, 0));
+										pack->m_headers["Info"] = Trim(cap->GetText(cap->m_samples.size()-1));
 										break;
 
 									default:
@@ -1388,620 +1388,609 @@ uint8_t ESPIDecoder::UpdateCRC8(uint8_t crc, uint8_t data)
 	return crc;
 }
 
-Gdk::Color ESPIDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color ESPIWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<ESPIWaveform*>(GetData(0));
-	if(capture != NULL)
+	const ESPISymbol& s = m_samples[i];
+
+	switch(s.m_type)
 	{
-		const ESPISymbol& s = capture->m_samples[i];
+		case ESPISymbol::TYPE_COMMAND_TYPE:
+		case ESPISymbol::TYPE_RESPONSE_OP:
+		case ESPISymbol::TYPE_RESPONSE_STATUS:
+		case ESPISymbol::TYPE_FLASH_REQUEST_TYPE:
+		case ESPISymbol::TYPE_REQUEST_LEN:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-		switch(s.m_type)
-		{
-			case ESPISymbol::TYPE_COMMAND_TYPE:
-			case ESPISymbol::TYPE_RESPONSE_OP:
-			case ESPISymbol::TYPE_RESPONSE_STATUS:
-			case ESPISymbol::TYPE_FLASH_REQUEST_TYPE:
-			case ESPISymbol::TYPE_REQUEST_LEN:
+		case ESPISymbol::TYPE_WAIT:
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
+
+		case ESPISymbol::TYPE_CAPS_ADDR:
+		case ESPISymbol::TYPE_VWIRE_COUNT:
+		case ESPISymbol::TYPE_VWIRE_INDEX:
+		case ESPISymbol::TYPE_REQUEST_TAG:
+		case ESPISymbol::TYPE_FLASH_REQUEST_ADDR:
+		case ESPISymbol::TYPE_SMBUS_REQUEST_ADDR:
+		case ESPISymbol::TYPE_IO_ADDR:
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
+
+		case ESPISymbol::TYPE_COMMAND_CRC_GOOD:
+		case ESPISymbol::TYPE_RESPONSE_CRC_GOOD:
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
+		case ESPISymbol::TYPE_COMMAND_CRC_BAD:
+		case ESPISymbol::TYPE_RESPONSE_CRC_BAD:
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
+
+		case ESPISymbol::TYPE_GENERAL_CAPS:
+		case ESPISymbol::TYPE_CH0_CAPS_RD:
+		case ESPISymbol::TYPE_CH0_CAPS_WR:
+		case ESPISymbol::TYPE_CH1_CAPS_RD:
+		case ESPISymbol::TYPE_CH1_CAPS_WR:
+		case ESPISymbol::TYPE_CH2_CAPS_RD:
+		case ESPISymbol::TYPE_CH2_CAPS_WR:
+		case ESPISymbol::TYPE_VWIRE_DATA:
+		case ESPISymbol::TYPE_COMMAND_DATA_32:
+		case ESPISymbol::TYPE_RESPONSE_DATA_32:
+		case ESPISymbol::TYPE_FLASH_REQUEST_DATA:
+		case ESPISymbol::TYPE_SMBUS_REQUEST_DATA:
+		case ESPISymbol::TYPE_IO_DATA:
+		case ESPISymbol::TYPE_COMPLETION_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
+
+		case ESPISymbol::TYPE_SMBUS_REQUEST_TYPE:
+			if(s.m_data == ESPISymbol::CYCLE_SMBUS)
 				return StandardColors::colors[StandardColors::COLOR_CONTROL];
-
-			case ESPISymbol::TYPE_WAIT:
-				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
-
-			case ESPISymbol::TYPE_CAPS_ADDR:
-			case ESPISymbol::TYPE_VWIRE_COUNT:
-			case ESPISymbol::TYPE_VWIRE_INDEX:
-			case ESPISymbol::TYPE_REQUEST_TAG:
-			case ESPISymbol::TYPE_FLASH_REQUEST_ADDR:
-			case ESPISymbol::TYPE_SMBUS_REQUEST_ADDR:
-			case ESPISymbol::TYPE_IO_ADDR:
-				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
-
-			case ESPISymbol::TYPE_COMMAND_CRC_GOOD:
-			case ESPISymbol::TYPE_RESPONSE_CRC_GOOD:
-				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
-			case ESPISymbol::TYPE_COMMAND_CRC_BAD:
-			case ESPISymbol::TYPE_RESPONSE_CRC_BAD:
-				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
-
-			case ESPISymbol::TYPE_GENERAL_CAPS:
-			case ESPISymbol::TYPE_CH0_CAPS_RD:
-			case ESPISymbol::TYPE_CH0_CAPS_WR:
-			case ESPISymbol::TYPE_CH1_CAPS_RD:
-			case ESPISymbol::TYPE_CH1_CAPS_WR:
-			case ESPISymbol::TYPE_CH2_CAPS_RD:
-			case ESPISymbol::TYPE_CH2_CAPS_WR:
-			case ESPISymbol::TYPE_VWIRE_DATA:
-			case ESPISymbol::TYPE_COMMAND_DATA_32:
-			case ESPISymbol::TYPE_RESPONSE_DATA_32:
-			case ESPISymbol::TYPE_FLASH_REQUEST_DATA:
-			case ESPISymbol::TYPE_SMBUS_REQUEST_DATA:
-			case ESPISymbol::TYPE_IO_DATA:
-			case ESPISymbol::TYPE_COMPLETION_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
-
-			case ESPISymbol::TYPE_SMBUS_REQUEST_TYPE:
-				if(s.m_data == ESPISymbol::CYCLE_SMBUS)
-					return StandardColors::colors[StandardColors::COLOR_CONTROL];
-				else
-					return StandardColors::colors[StandardColors::COLOR_ERROR];
-
-			case ESPISymbol::TYPE_COMPLETION_TYPE:
-				switch(s.m_data)
-				{
-					case ESPISymbol::CYCLE_SUCCESS_NODATA:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_MIDDLE:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_FIRST:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_LAST:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_ONLY:
-						return StandardColors::colors[StandardColors::COLOR_CONTROL];
-
-					case ESPISymbol::CYCLE_FAIL_LAST:
-					case ESPISymbol::CYCLE_FAIL_ONLY:
-					default:
-						return StandardColors::colors[StandardColors::COLOR_ERROR];
-				};
-				break;
-
-			default:
+			else
 				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
-	}
 
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
+		case ESPISymbol::TYPE_COMPLETION_TYPE:
+			switch(s.m_data)
+			{
+				case ESPISymbol::CYCLE_SUCCESS_NODATA:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_MIDDLE:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_FIRST:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_LAST:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_ONLY:
+					return StandardColors::colors[StandardColors::COLOR_CONTROL];
+
+				case ESPISymbol::CYCLE_FAIL_LAST:
+				case ESPISymbol::CYCLE_FAIL_ONLY:
+				default:
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
+			};
+			break;
+
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
+	}
 }
 
-string ESPIDecoder::GetText(size_t i, size_t /*stream*/)
+string ESPIWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<ESPIWaveform*>(GetData(0));
-	if(capture != NULL)
+	const ESPISymbol& s = m_samples[i];
+	char tmp[128];
+	string stmp;
+
+	switch(s.m_type)
 	{
-		const ESPISymbol& s = capture->m_samples[i];
-		char tmp[128];
-		string stmp;
-
-		switch(s.m_type)
-		{
-			case ESPISymbol::TYPE_COMMAND_TYPE:
-				switch(s.m_data)
-				{
-					case ESPISymbol::COMMAND_GET_CONFIGURATION:
-						return "Get Configuration";
-					case ESPISymbol::COMMAND_SET_CONFIGURATION:
-						return "Set Configuration";
-
-					case ESPISymbol::COMMAND_GET_OOB:
-						return "Get OOB";
-					case ESPISymbol::COMMAND_PUT_OOB:
-						return "Put OOB";
-
-					case ESPISymbol::COMMAND_GET_PC:
-						return "Get Posted Completion";
-					case ESPISymbol::COMMAND_PUT_PC:
-						return "Put PC";
-
-					case ESPISymbol::COMMAND_GET_STATUS:
-						return "Get Status";
-
-					case ESPISymbol::COMMAND_GET_FLASH_NP:
-						return "Get Flash Non-Posted";
-					case ESPISymbol::COMMAND_PUT_FLASH_C:
-						return "Put Flash Completion";
-
-					case ESPISymbol::COMMAND_GET_VWIRE:
-						return "Get Virtual Wire";
-					case ESPISymbol::COMMAND_PUT_VWIRE:
-						return "Put Virtual Wire";
-
-					case ESPISymbol::COMMAND_PUT_IOWR_SHORT_x1:
-					case ESPISymbol::COMMAND_PUT_IOWR_SHORT_x2:
-					case ESPISymbol::COMMAND_PUT_IOWR_SHORT_x4:
-						return "Put I/O Write";
-
-					case ESPISymbol::COMMAND_PUT_IORD_SHORT_x1:
-					case ESPISymbol::COMMAND_PUT_IORD_SHORT_x2:
-					case ESPISymbol::COMMAND_PUT_IORD_SHORT_x4:
-						return "Put I/O Read";
-
-					default:
-						snprintf(tmp, sizeof(tmp), "Unknown Cmd (%02lx)", s.m_data);
-						return tmp;
-				}
-				break;
-
-			case ESPISymbol::TYPE_CAPS_ADDR:
-				switch(s.m_data)
-				{
-					case 0x04:	return "Device ID";
-					case 0x08:	return "General Capabilities";
-					case 0x10:	return "CH0 Capabilities";
-					case 0x20:	return "CH1 Capabilities";
-					case 0x30:	return "CH2 Capabilities";
-					case 0x40:	return "CH3 Capabilities";
-
-					//Print as hex if unknown
-					default:
-						snprintf(tmp, sizeof(tmp), "%04lx", s.m_data);
-						return tmp;
-				}
-
-			case ESPISymbol::TYPE_COMMAND_CRC_GOOD:
-			case ESPISymbol::TYPE_COMMAND_CRC_BAD:
-			case ESPISymbol::TYPE_RESPONSE_CRC_GOOD:
-			case ESPISymbol::TYPE_RESPONSE_CRC_BAD:
-				return string("CRC: ") + to_string_hex(s.m_data);
-
-			case ESPISymbol::TYPE_VWIRE_COUNT:
-				return string("Count: ") + to_string(s.m_data + 1);
-
-			case ESPISymbol::TYPE_VWIRE_INDEX:
-				return string("Index: ") + to_string_hex(s.m_data);
-
-			case ESPISymbol::TYPE_VWIRE_DATA:
-				snprintf(tmp, sizeof(tmp), "%02lx", s.m_data);
-				return tmp;
-
-			case ESPISymbol::TYPE_RESPONSE_OP:
-				switch(s.m_data & 0xf)
-				{
-					case ESPISymbol::RESPONSE_DEFER:
-						return "Defer";
-
-					case ESPISymbol::RESPONSE_NONFATAL_ERROR:
-						return "Nonfatal Error";
-
-					case ESPISymbol::RESPONSE_FATAL_ERROR:
-						return "Fatal Error";
-
-					case ESPISymbol::RESPONSE_ACCEPT:
-						return "Accept";
-
-					case ESPISymbol::RESPONSE_NONE:
-						return "No Response";
-
-					default:
-						snprintf(tmp, sizeof(tmp), "Unknown response %lx", s.m_data & 0xf);
-						return tmp;
-				}
-				break;
-
-			case ESPISymbol::TYPE_GENERAL_CAPS:
-				if(s.m_data & 0x80000000)
-					stmp += "CRC checking enabled\n";
-				if(s.m_data & 0x40000000)
-					stmp += "Response modifier enabled\n";
-				if( (s.m_data & 0x10000000) == 0)
-					stmp += "DQ1 used as alert\n";
-				else
-					stmp += "ALERT# used as alert\n";
-				switch( (s.m_data >> 26) & 0x3)
-				{
-					case 0:
-						stmp += "x1 mode\n";
-						break;
-					case 1:
-
-						stmp += "x2 mode\n";
-						break;
-					case 2:
-						stmp += "x4 mode\n";
-						break;
-					default:
-						stmp += "Invalid IO mode\n";
-						break;
-				}
-
-				switch( (s.m_data >> 24) & 0x3)
-				{
-					case 0:
-						stmp += "Supports x1 mode only\n";
-						break;
-					case 1:
-						stmp += "Supports x1 and x2 modes\n";
-						break;
-					case 2:
-						stmp += "Supports x1 and x4 modes\n";
-						break;
-					default:
-						stmp += "Supports x1, x2, and x4 modes\n";
-						break;
-				}
-
-				if(s.m_data & 0x00800000)
-					stmp += "ALERT# configured as open drain\n";
-				else
-					stmp += "ALERT# configured as push-pull\n";
-
-				switch( (s.m_data >> 20) & 0x7)
-				{
-					case 0:
-						stmp += "20MHz SCK\n";
-						break;
-					case 1:
-						stmp += "25MHz SCK\n";
-						break;
-					case 2:
-						stmp += "33MHz SCK\n";
-						break;
-					case 3:
-						stmp += "50MHz SCK\n";
-						break;
-					case 4:
-						stmp += "66MHz SCK\n";
-						break;
-					default:
-						stmp += "Invalid SCK speed\n";
-						break;
-				}
-
-				if(s.m_data & 0x00080000)
-					stmp += "ALERT# supports open drain mode\n";
-
-				switch( (s.m_data >> 16) & 0x7)
-				{
-					case 0:
-						stmp += "Max SCK: 20 MHz\n";
-						break;
-					case 1:
-						stmp += "Max SCK: 25 MHz\n";
-						break;
-					case 2:
-						stmp += "Max SCK: 33 MHz\n";
-						break;
-					case 3:
-						stmp += "Max SCK: 50 MHz\n";
-						break;
-					case 4:
-						stmp += "Max SCK: 66 MHz\n";
-						break;
-					default:
-						stmp += "Invalid max SCK speed\n";
-						break;
-				}
-
-				//15:12 = max wait states
-				if( ( (s.m_data >> 12) & 0xf) == 0)
-					stmp += "Max wait states: 16\n";
-				else
-					stmp += string("Max wait states: ") + to_string((s.m_data >> 12) & 0xf) + "\n";
-
-				if(s.m_data & 0x80)
-					stmp += "Platform channel 7 present\n";
-				if(s.m_data & 0x40)
-					stmp += "Platform channel 6 present\n";
-				if(s.m_data & 0x20)
-					stmp += "Platform channel 5 present\n";
-				if(s.m_data & 0x10)
-					stmp += "Platform channel 4 present\n";
-				if(s.m_data & 0x08)
-					stmp += "Flash channel present\n";
-				if(s.m_data & 0x04)
-					stmp += "OOB channel present\n";
-				if(s.m_data & 0x02)
-					stmp += "Virtual wire channel present\n";
-				if(s.m_data & 0x01)
-					stmp += "Peripheral channel present\n";
-				return stmp;	//end TYPE_GENERAL_CAPS
-
-			case ESPISymbol::TYPE_CH0_CAPS_RD:
-
-				if(s.m_data & 2)
-					stmp += "Ready\n";
-				else
-					stmp += "Not ready\n";
-
-				switch( (s.m_data >> 4) & 0x7)
-				{
-					case 1:
-						stmp += "Max periph payload supported: 64\n";
-						break;
-					case 2:
-						stmp += "Max periph payload supported: 128\n";
-						break;
-					case 3:
-						stmp += "Max periph payload supported: 256\n";
-						break;
-
-					default:
-						stmp += "Max periph payload supported: reserved\n";
-						break;
-				}
-
-				//end CH0_CAPS_RD
-				//fall through
-
-			case ESPISymbol::TYPE_CH0_CAPS_WR:
-
-				switch( (s.m_data >> 8) & 0x7)
-				{
-					case 1:
-						stmp += "Max periph payload size: 64\n";
-						break;
-					case 2:
-						stmp += "Max periph payload size: 128\n";
-						break;
-					case 3:
-						stmp += "Max periph payload size: 256\n";
-						break;
-
-					default:
-						stmp += "Max periph payload size: reserved\n";
-						break;
-				}
-
-				switch( (s.m_data >> 12) & 0x7)
-				{
-					case 0:
-						stmp += "Max periph read size: reserved\n";
-						break;
-
-					case 1:
-						stmp += "Max periph read size: 64\n";
-						break;
-					case 2:
-						stmp += "Max periph read size: 128\n";
-						break;
-					case 3:
-						stmp += "Max periph read size: 256\n";
-						break;
-					case 4:
-						stmp += "Max periph read size: 512\n";
-						break;
-					case 5:
-						stmp += "Max periph read size: 1024\n";
-						break;
-					case 6:
-						stmp += "Max periph read size: 2048\n";
-						break;
-					case 7:
-						stmp += "Max periph read size: 4096\n";
-						break;
-				}
-
-				if(s.m_data & 4)
-					stmp += "Bus mastering enabled\n";
-				else
-					stmp += "Bus mastering disabled\n";
-
-				if(s.m_data & 1)
-					stmp += "Enabled\n";
-				else
-					stmp += "Disabled\n";
-
-				return stmp;	//end TYPE_CH0_CAPS_WR
-
-			case ESPISymbol::TYPE_CH1_CAPS_RD:
-				stmp += "Operating max vwires: ";
-				stmp += to_string( ((s.m_data >> 16) & 0x3f) + 1) + "\n";
-
-				stmp += "Max vwires supported: ";
-				stmp += to_string( ((s.m_data >> 8) & 0x3f) + 1) + "\n";
-
-				if(s.m_data & 2)
-					stmp += "Ready\n";
-				else
-					stmp += "Not ready\n";
-
-				if(s.m_data & 1)
-					stmp += "Enabled\n";
-				else
-					stmp += "Disabled\n";
-
-				return stmp;	//end TYPE_CH1_CAPS_RD
-
-			case ESPISymbol::TYPE_CH1_CAPS_WR:
-				stmp += "Operating max vwires: ";
-				stmp += to_string( ((s.m_data >> 16) & 0x3f) + 1) + "\n";
-
-				if(s.m_data & 1)
-					stmp += "Enabled\n";
-				else
-					stmp += "Disabled\n";
-
-				return stmp;	//end TYPE_CH1_CAPS_WR
-
-			case ESPISymbol::TYPE_CH2_CAPS_RD:
-
-				stmp += "Max OOB payload selected: ";
-				switch( (s.m_data >> 8) & 0x7)
-				{
-					case 1:
-						stmp += "64 bytes\n";
-						break;
-					case 2:
-						stmp += "128 bytes\n";
-						break;
-					case 3:
-						stmp += "256 bytes\n";
-						break;
-					default:
-						stmp += "Reserved\n";
-						break;
-				}
-
-				stmp += "Max OOB payload supported: ";
-				switch( (s.m_data >> 4) & 0x7)
-				{
-					case 1:
-						stmp += "64 bytes\n";
-						break;
-					case 2:
-						stmp += "128 bytes\n";
-						break;
-					case 3:
-						stmp += "256 bytes\n";
-						break;
-					default:
-						stmp += "Reserved\n";
-						break;
-				}
-
-				if(s.m_data & 2)
-					stmp += "OOB channel ready\n";
-				else
-					stmp += "OOB channel not ready\n";
-
-				if(s.m_data & 1)
-					stmp += "OOB channel enabled\n";
-				else
-					stmp += "OOB channel disabled\n";
-
-				return stmp;	//end TYPE_CH2_CAPS_RD
-
-			case ESPISymbol::TYPE_CH2_CAPS_WR:
-
-				stmp += "Max OOB payload selected: ";
-				switch( (s.m_data >> 8) & 0x7)
-				{
-					case 1:
-						stmp += "64 bytes\n";
-						break;
-					case 2:
-						stmp += "128 bytes\n";
-						break;
-					case 3:
-						stmp += "256 bytes\n";
-						break;
-					default:
-						stmp += "Reserved\n";
-						break;
-				}
-
-				if(s.m_data & 1)
-					stmp += "OOB channel enabled\n";
-				else
-					stmp += "OOB channel disabled\n";
-
-				return stmp;	//end TYPE_CH2_CAPS_WR
-
-			case ESPISymbol::TYPE_RESPONSE_DATA_32:
-			case ESPISymbol::TYPE_COMMAND_DATA_32:
-				snprintf(tmp, sizeof(tmp), "%08lx", s.m_data);
-				return tmp;
-
-			case ESPISymbol::TYPE_RESPONSE_STATUS:
-				if(s.m_data & 0x2000)
-					stmp += "FLASH_NP_AVAIL ";
-				if(s.m_data & 0x1000)
-					stmp += "FLASH_C_AVAIL ";
-				if(s.m_data & 0x0200)
-					stmp += "FLASH_NP_FREE ";
-				if(s.m_data & 0x0080)
-					stmp += "OOB_AVAIL ";
-				if(s.m_data & 0x0040)
-					stmp += "VWIRE_AVAIL ";
-				if(s.m_data & 0x0020)
-					stmp += "NP_AVAIL ";
-				if(s.m_data & 0x0010)
-					stmp += "PC_AVAIL ";
-				if(s.m_data & 0x0008)
-					stmp += "OOB_FREE ";
-				if(s.m_data & 0x0002)
-					stmp += "NP_FREE ";
-				if(s.m_data & 0x0001)
-					stmp += "PC_FREE";
-				return stmp;
-
-			case ESPISymbol::TYPE_FLASH_REQUEST_TYPE:
-				switch(s.m_data)
-				{
-					case ESPISymbol::CYCLE_READ:
-						return "Read";
-					case ESPISymbol::CYCLE_WRITE:
-						return "Write";
-					case ESPISymbol::CYCLE_ERASE:
-						return "Erase";
-
-					case ESPISymbol::CYCLE_SUCCESS_NODATA:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_FIRST:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_MIDDLE:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_LAST:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_ONLY:
-						return "Success";
-				}
-				break;
-
-			case ESPISymbol::TYPE_REQUEST_TAG:
-				return string("Tag: ") + to_string(s.m_data);
-
-			case ESPISymbol::TYPE_REQUEST_LEN:
-				return string("Len: ") + to_string(s.m_data);
-
-			case ESPISymbol::TYPE_FLASH_REQUEST_DATA:
-			case ESPISymbol::TYPE_IO_DATA:
-			case ESPISymbol::TYPE_COMPLETION_DATA:
-				snprintf(tmp, sizeof(tmp), "%02lx", s.m_data);
-				return tmp;
-
-			case ESPISymbol::TYPE_FLASH_REQUEST_ADDR:
-				snprintf(tmp, sizeof(tmp), "Addr: %08lx", s.m_data);
-				return tmp;
-
-			case ESPISymbol::TYPE_IO_ADDR:
-				snprintf(tmp, sizeof(tmp), "Addr: %04lx", s.m_data);
-				return tmp;
-
-			case ESPISymbol::TYPE_SMBUS_REQUEST_ADDR:
-				snprintf(tmp, sizeof(tmp), "Addr: %02lx", s.m_data);
-				return tmp;
-
-			case ESPISymbol::TYPE_SMBUS_REQUEST_TYPE:
-				if(s.m_data == ESPISymbol::CYCLE_SMBUS)
-					return "SMBus Msg";
-				else
-					return "Invalid";
-
-			case ESPISymbol::TYPE_SMBUS_REQUEST_DATA:
-				snprintf(tmp, sizeof(tmp), "%02lx", s.m_data);
-				return tmp;
-
-			case ESPISymbol::TYPE_COMPLETION_TYPE:
-				switch(s.m_data)
-				{
-					case ESPISymbol::CYCLE_SUCCESS_NODATA:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_MIDDLE:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_FIRST:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_LAST:
-					case ESPISymbol::CYCLE_SUCCESS_DATA_ONLY:
-						return "Success";
-
-					case ESPISymbol::CYCLE_FAIL_LAST:
-					case ESPISymbol::CYCLE_FAIL_ONLY:
-						return "Fail";
-
-					default:
-						return "ERROR";
-				};
-				break;
-
-			case ESPISymbol::TYPE_WAIT:
-				return "Wait";
-
-			case ESPISymbol::TYPE_ERROR:
-			default:
-				return "ERROR";
-		}
+		case ESPISymbol::TYPE_COMMAND_TYPE:
+			switch(s.m_data)
+			{
+				case ESPISymbol::COMMAND_GET_CONFIGURATION:
+					return "Get Configuration";
+				case ESPISymbol::COMMAND_SET_CONFIGURATION:
+					return "Set Configuration";
+
+				case ESPISymbol::COMMAND_GET_OOB:
+					return "Get OOB";
+				case ESPISymbol::COMMAND_PUT_OOB:
+					return "Put OOB";
+
+				case ESPISymbol::COMMAND_GET_PC:
+					return "Get Posted Completion";
+				case ESPISymbol::COMMAND_PUT_PC:
+					return "Put PC";
+
+				case ESPISymbol::COMMAND_GET_STATUS:
+					return "Get Status";
+
+				case ESPISymbol::COMMAND_GET_FLASH_NP:
+					return "Get Flash Non-Posted";
+				case ESPISymbol::COMMAND_PUT_FLASH_C:
+					return "Put Flash Completion";
+
+				case ESPISymbol::COMMAND_GET_VWIRE:
+					return "Get Virtual Wire";
+				case ESPISymbol::COMMAND_PUT_VWIRE:
+					return "Put Virtual Wire";
+
+				case ESPISymbol::COMMAND_PUT_IOWR_SHORT_x1:
+				case ESPISymbol::COMMAND_PUT_IOWR_SHORT_x2:
+				case ESPISymbol::COMMAND_PUT_IOWR_SHORT_x4:
+					return "Put I/O Write";
+
+				case ESPISymbol::COMMAND_PUT_IORD_SHORT_x1:
+				case ESPISymbol::COMMAND_PUT_IORD_SHORT_x2:
+				case ESPISymbol::COMMAND_PUT_IORD_SHORT_x4:
+					return "Put I/O Read";
+
+				default:
+					snprintf(tmp, sizeof(tmp), "Unknown Cmd (%02lx)", s.m_data);
+					return tmp;
+			}
+			break;
+
+		case ESPISymbol::TYPE_CAPS_ADDR:
+			switch(s.m_data)
+			{
+				case 0x04:	return "Device ID";
+				case 0x08:	return "General Capabilities";
+				case 0x10:	return "CH0 Capabilities";
+				case 0x20:	return "CH1 Capabilities";
+				case 0x30:	return "CH2 Capabilities";
+				case 0x40:	return "CH3 Capabilities";
+
+				//Print as hex if unknown
+				default:
+					snprintf(tmp, sizeof(tmp), "%04lx", s.m_data);
+					return tmp;
+			}
+
+		case ESPISymbol::TYPE_COMMAND_CRC_GOOD:
+		case ESPISymbol::TYPE_COMMAND_CRC_BAD:
+		case ESPISymbol::TYPE_RESPONSE_CRC_GOOD:
+		case ESPISymbol::TYPE_RESPONSE_CRC_BAD:
+			return string("CRC: ") + to_string_hex(s.m_data);
+
+		case ESPISymbol::TYPE_VWIRE_COUNT:
+			return string("Count: ") + to_string(s.m_data + 1);
+
+		case ESPISymbol::TYPE_VWIRE_INDEX:
+			return string("Index: ") + to_string_hex(s.m_data);
+
+		case ESPISymbol::TYPE_VWIRE_DATA:
+			snprintf(tmp, sizeof(tmp), "%02lx", s.m_data);
+			return tmp;
+
+		case ESPISymbol::TYPE_RESPONSE_OP:
+			switch(s.m_data & 0xf)
+			{
+				case ESPISymbol::RESPONSE_DEFER:
+					return "Defer";
+
+				case ESPISymbol::RESPONSE_NONFATAL_ERROR:
+					return "Nonfatal Error";
+
+				case ESPISymbol::RESPONSE_FATAL_ERROR:
+					return "Fatal Error";
+
+				case ESPISymbol::RESPONSE_ACCEPT:
+					return "Accept";
+
+				case ESPISymbol::RESPONSE_NONE:
+					return "No Response";
+
+				default:
+					snprintf(tmp, sizeof(tmp), "Unknown response %lx", s.m_data & 0xf);
+					return tmp;
+			}
+			break;
+
+		case ESPISymbol::TYPE_GENERAL_CAPS:
+			if(s.m_data & 0x80000000)
+				stmp += "CRC checking enabled\n";
+			if(s.m_data & 0x40000000)
+				stmp += "Response modifier enabled\n";
+			if( (s.m_data & 0x10000000) == 0)
+				stmp += "DQ1 used as alert\n";
+			else
+				stmp += "ALERT# used as alert\n";
+			switch( (s.m_data >> 26) & 0x3)
+			{
+				case 0:
+					stmp += "x1 mode\n";
+					break;
+				case 1:
+
+					stmp += "x2 mode\n";
+					break;
+				case 2:
+					stmp += "x4 mode\n";
+					break;
+				default:
+					stmp += "Invalid IO mode\n";
+					break;
+			}
+
+			switch( (s.m_data >> 24) & 0x3)
+			{
+				case 0:
+					stmp += "Supports x1 mode only\n";
+					break;
+				case 1:
+					stmp += "Supports x1 and x2 modes\n";
+					break;
+				case 2:
+					stmp += "Supports x1 and x4 modes\n";
+					break;
+				default:
+					stmp += "Supports x1, x2, and x4 modes\n";
+					break;
+			}
+
+			if(s.m_data & 0x00800000)
+				stmp += "ALERT# configured as open drain\n";
+			else
+				stmp += "ALERT# configured as push-pull\n";
+
+			switch( (s.m_data >> 20) & 0x7)
+			{
+				case 0:
+					stmp += "20MHz SCK\n";
+					break;
+				case 1:
+					stmp += "25MHz SCK\n";
+					break;
+				case 2:
+					stmp += "33MHz SCK\n";
+					break;
+				case 3:
+					stmp += "50MHz SCK\n";
+					break;
+				case 4:
+					stmp += "66MHz SCK\n";
+					break;
+				default:
+					stmp += "Invalid SCK speed\n";
+					break;
+			}
+
+			if(s.m_data & 0x00080000)
+				stmp += "ALERT# supports open drain mode\n";
+
+			switch( (s.m_data >> 16) & 0x7)
+			{
+				case 0:
+					stmp += "Max SCK: 20 MHz\n";
+					break;
+				case 1:
+					stmp += "Max SCK: 25 MHz\n";
+					break;
+				case 2:
+					stmp += "Max SCK: 33 MHz\n";
+					break;
+				case 3:
+					stmp += "Max SCK: 50 MHz\n";
+					break;
+				case 4:
+					stmp += "Max SCK: 66 MHz\n";
+					break;
+				default:
+					stmp += "Invalid max SCK speed\n";
+					break;
+			}
+
+			//15:12 = max wait states
+			if( ( (s.m_data >> 12) & 0xf) == 0)
+				stmp += "Max wait states: 16\n";
+			else
+				stmp += string("Max wait states: ") + to_string((s.m_data >> 12) & 0xf) + "\n";
+
+			if(s.m_data & 0x80)
+				stmp += "Platform channel 7 present\n";
+			if(s.m_data & 0x40)
+				stmp += "Platform channel 6 present\n";
+			if(s.m_data & 0x20)
+				stmp += "Platform channel 5 present\n";
+			if(s.m_data & 0x10)
+				stmp += "Platform channel 4 present\n";
+			if(s.m_data & 0x08)
+				stmp += "Flash channel present\n";
+			if(s.m_data & 0x04)
+				stmp += "OOB channel present\n";
+			if(s.m_data & 0x02)
+				stmp += "Virtual wire channel present\n";
+			if(s.m_data & 0x01)
+				stmp += "Peripheral channel present\n";
+			return stmp;	//end TYPE_GENERAL_CAPS
+
+		case ESPISymbol::TYPE_CH0_CAPS_RD:
+
+			if(s.m_data & 2)
+				stmp += "Ready\n";
+			else
+				stmp += "Not ready\n";
+
+			switch( (s.m_data >> 4) & 0x7)
+			{
+				case 1:
+					stmp += "Max periph payload supported: 64\n";
+					break;
+				case 2:
+					stmp += "Max periph payload supported: 128\n";
+					break;
+				case 3:
+					stmp += "Max periph payload supported: 256\n";
+					break;
+
+				default:
+					stmp += "Max periph payload supported: reserved\n";
+					break;
+			}
+
+			//end CH0_CAPS_RD
+			//fall through
+
+		case ESPISymbol::TYPE_CH0_CAPS_WR:
+
+			switch( (s.m_data >> 8) & 0x7)
+			{
+				case 1:
+					stmp += "Max periph payload size: 64\n";
+					break;
+				case 2:
+					stmp += "Max periph payload size: 128\n";
+					break;
+				case 3:
+					stmp += "Max periph payload size: 256\n";
+					break;
+
+				default:
+					stmp += "Max periph payload size: reserved\n";
+					break;
+			}
+
+			switch( (s.m_data >> 12) & 0x7)
+			{
+				case 0:
+					stmp += "Max periph read size: reserved\n";
+					break;
+
+				case 1:
+					stmp += "Max periph read size: 64\n";
+					break;
+				case 2:
+					stmp += "Max periph read size: 128\n";
+					break;
+				case 3:
+					stmp += "Max periph read size: 256\n";
+					break;
+				case 4:
+					stmp += "Max periph read size: 512\n";
+					break;
+				case 5:
+					stmp += "Max periph read size: 1024\n";
+					break;
+				case 6:
+					stmp += "Max periph read size: 2048\n";
+					break;
+				case 7:
+					stmp += "Max periph read size: 4096\n";
+					break;
+			}
+
+			if(s.m_data & 4)
+				stmp += "Bus mastering enabled\n";
+			else
+				stmp += "Bus mastering disabled\n";
+
+			if(s.m_data & 1)
+				stmp += "Enabled\n";
+			else
+				stmp += "Disabled\n";
+
+			return stmp;	//end TYPE_CH0_CAPS_WR
+
+		case ESPISymbol::TYPE_CH1_CAPS_RD:
+			stmp += "Operating max vwires: ";
+			stmp += to_string( ((s.m_data >> 16) & 0x3f) + 1) + "\n";
+
+			stmp += "Max vwires supported: ";
+			stmp += to_string( ((s.m_data >> 8) & 0x3f) + 1) + "\n";
+
+			if(s.m_data & 2)
+				stmp += "Ready\n";
+			else
+				stmp += "Not ready\n";
+
+			if(s.m_data & 1)
+				stmp += "Enabled\n";
+			else
+				stmp += "Disabled\n";
+
+			return stmp;	//end TYPE_CH1_CAPS_RD
+
+		case ESPISymbol::TYPE_CH1_CAPS_WR:
+			stmp += "Operating max vwires: ";
+			stmp += to_string( ((s.m_data >> 16) & 0x3f) + 1) + "\n";
+
+			if(s.m_data & 1)
+				stmp += "Enabled\n";
+			else
+				stmp += "Disabled\n";
+
+			return stmp;	//end TYPE_CH1_CAPS_WR
+
+		case ESPISymbol::TYPE_CH2_CAPS_RD:
+
+			stmp += "Max OOB payload selected: ";
+			switch( (s.m_data >> 8) & 0x7)
+			{
+				case 1:
+					stmp += "64 bytes\n";
+					break;
+				case 2:
+					stmp += "128 bytes\n";
+					break;
+				case 3:
+					stmp += "256 bytes\n";
+					break;
+				default:
+					stmp += "Reserved\n";
+					break;
+			}
+
+			stmp += "Max OOB payload supported: ";
+			switch( (s.m_data >> 4) & 0x7)
+			{
+				case 1:
+					stmp += "64 bytes\n";
+					break;
+				case 2:
+					stmp += "128 bytes\n";
+					break;
+				case 3:
+					stmp += "256 bytes\n";
+					break;
+				default:
+					stmp += "Reserved\n";
+					break;
+			}
+
+			if(s.m_data & 2)
+				stmp += "OOB channel ready\n";
+			else
+				stmp += "OOB channel not ready\n";
+
+			if(s.m_data & 1)
+				stmp += "OOB channel enabled\n";
+			else
+				stmp += "OOB channel disabled\n";
+
+			return stmp;	//end TYPE_CH2_CAPS_RD
+
+		case ESPISymbol::TYPE_CH2_CAPS_WR:
+
+			stmp += "Max OOB payload selected: ";
+			switch( (s.m_data >> 8) & 0x7)
+			{
+				case 1:
+					stmp += "64 bytes\n";
+					break;
+				case 2:
+					stmp += "128 bytes\n";
+					break;
+				case 3:
+					stmp += "256 bytes\n";
+					break;
+				default:
+					stmp += "Reserved\n";
+					break;
+			}
+
+			if(s.m_data & 1)
+				stmp += "OOB channel enabled\n";
+			else
+				stmp += "OOB channel disabled\n";
+
+			return stmp;	//end TYPE_CH2_CAPS_WR
+
+		case ESPISymbol::TYPE_RESPONSE_DATA_32:
+		case ESPISymbol::TYPE_COMMAND_DATA_32:
+			snprintf(tmp, sizeof(tmp), "%08lx", s.m_data);
+			return tmp;
+
+		case ESPISymbol::TYPE_RESPONSE_STATUS:
+			if(s.m_data & 0x2000)
+				stmp += "FLASH_NP_AVAIL ";
+			if(s.m_data & 0x1000)
+				stmp += "FLASH_C_AVAIL ";
+			if(s.m_data & 0x0200)
+				stmp += "FLASH_NP_FREE ";
+			if(s.m_data & 0x0080)
+				stmp += "OOB_AVAIL ";
+			if(s.m_data & 0x0040)
+				stmp += "VWIRE_AVAIL ";
+			if(s.m_data & 0x0020)
+				stmp += "NP_AVAIL ";
+			if(s.m_data & 0x0010)
+				stmp += "PC_AVAIL ";
+			if(s.m_data & 0x0008)
+				stmp += "OOB_FREE ";
+			if(s.m_data & 0x0002)
+				stmp += "NP_FREE ";
+			if(s.m_data & 0x0001)
+				stmp += "PC_FREE";
+			return stmp;
+
+		case ESPISymbol::TYPE_FLASH_REQUEST_TYPE:
+			switch(s.m_data)
+			{
+				case ESPISymbol::CYCLE_READ:
+					return "Read";
+				case ESPISymbol::CYCLE_WRITE:
+					return "Write";
+				case ESPISymbol::CYCLE_ERASE:
+					return "Erase";
+
+				case ESPISymbol::CYCLE_SUCCESS_NODATA:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_FIRST:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_MIDDLE:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_LAST:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_ONLY:
+					return "Success";
+			}
+			break;
+
+		case ESPISymbol::TYPE_REQUEST_TAG:
+			return string("Tag: ") + to_string(s.m_data);
+
+		case ESPISymbol::TYPE_REQUEST_LEN:
+			return string("Len: ") + to_string(s.m_data);
+
+		case ESPISymbol::TYPE_FLASH_REQUEST_DATA:
+		case ESPISymbol::TYPE_IO_DATA:
+		case ESPISymbol::TYPE_COMPLETION_DATA:
+			snprintf(tmp, sizeof(tmp), "%02lx", s.m_data);
+			return tmp;
+
+		case ESPISymbol::TYPE_FLASH_REQUEST_ADDR:
+			snprintf(tmp, sizeof(tmp), "Addr: %08lx", s.m_data);
+			return tmp;
+
+		case ESPISymbol::TYPE_IO_ADDR:
+			snprintf(tmp, sizeof(tmp), "Addr: %04lx", s.m_data);
+			return tmp;
+
+		case ESPISymbol::TYPE_SMBUS_REQUEST_ADDR:
+			snprintf(tmp, sizeof(tmp), "Addr: %02lx", s.m_data);
+			return tmp;
+
+		case ESPISymbol::TYPE_SMBUS_REQUEST_TYPE:
+			if(s.m_data == ESPISymbol::CYCLE_SMBUS)
+				return "SMBus Msg";
+			else
+				return "Invalid";
+
+		case ESPISymbol::TYPE_SMBUS_REQUEST_DATA:
+			snprintf(tmp, sizeof(tmp), "%02lx", s.m_data);
+			return tmp;
+
+		case ESPISymbol::TYPE_COMPLETION_TYPE:
+			switch(s.m_data)
+			{
+				case ESPISymbol::CYCLE_SUCCESS_NODATA:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_MIDDLE:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_FIRST:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_LAST:
+				case ESPISymbol::CYCLE_SUCCESS_DATA_ONLY:
+					return "Success";
+
+				case ESPISymbol::CYCLE_FAIL_LAST:
+				case ESPISymbol::CYCLE_FAIL_ONLY:
+					return "Fail";
+
+				default:
+					return "ERROR";
+			};
+			break;
+
+		case ESPISymbol::TYPE_WAIT:
+			return "Wait";
+
+		case ESPISymbol::TYPE_ERROR:
+		default:
+			return "ERROR";
 	}
-	return "";
 }
 
 bool ESPIDecoder::CanMerge(Packet* first, Packet* /*cur*/, Packet* next)

--- a/scopeprotocols/ESPIDecoder.h
+++ b/scopeprotocols/ESPIDecoder.h
@@ -184,7 +184,13 @@ public:
 	}
 };
 
-typedef Waveform<ESPISymbol> ESPIWaveform;
+class ESPIWaveform : public Waveform<ESPISymbol>
+{
+public:
+	ESPIWaveform () : Waveform<ESPISymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 /**
 	@brief Decoder for Intel Enhanced Serial Peripheral Interface (eSPI)

--- a/scopeprotocols/ESPIDecoder.h
+++ b/scopeprotocols/ESPIDecoder.h
@@ -196,9 +196,6 @@ class ESPIDecoder : public PacketDecoder
 public:
 	ESPIDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	std::vector<std::string> GetHeaders();

--- a/scopeprotocols/Ethernet64b66bDecoder.cpp
+++ b/scopeprotocols/Ethernet64b66bDecoder.cpp
@@ -186,18 +186,18 @@ Gdk::Color Ethernet64b66bDecoder::GetColor(size_t i, size_t /*stream*/)
 		switch(s.m_header)
 		{
 			case 1:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case 2:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
 	//error
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string Ethernet64b66bDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/Ethernet64b66bDecoder.cpp
+++ b/scopeprotocols/Ethernet64b66bDecoder.cpp
@@ -176,42 +176,29 @@ void Ethernet64b66bDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color Ethernet64b66bDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color Ethernet64b66bWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<Ethernet64b66bWaveform*>(GetData(0));
-	if(capture != NULL)
+	const Ethernet64b66bSymbol& s = m_samples[i];
+
+	switch(s.m_header)
 	{
-		const Ethernet64b66bSymbol& s = capture->m_samples[i];
+		case 1:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-		switch(s.m_header)
-		{
-			case 1:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
+		case 2:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case 2:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
-
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	//error
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string Ethernet64b66bDecoder::GetText(size_t i, size_t /*stream*/)
+string Ethernet64b66bWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<Ethernet64b66bWaveform*>(GetData(0));
-	if(capture != NULL)
-	{
-		const Ethernet64b66bSymbol& s = capture->m_samples[i];
+	const Ethernet64b66bSymbol& s = m_samples[i];
 
-		char tmp[32];
-		snprintf(tmp, sizeof(tmp), "%016lx", s.m_data);
-		return string(tmp);
-	}
-
-	return "";
+	char tmp[32];
+	snprintf(tmp, sizeof(tmp), "%016lx", s.m_data);
+	return string(tmp);
 }
 

--- a/scopeprotocols/Ethernet64b66bDecoder.h
+++ b/scopeprotocols/Ethernet64b66bDecoder.h
@@ -56,7 +56,13 @@ public:
 	}
 };
 
-typedef Waveform<Ethernet64b66bSymbol> Ethernet64b66bWaveform;
+class Ethernet64b66bWaveform : public Waveform<Ethernet64b66bSymbol>
+{
+public:
+	Ethernet64b66bWaveform () : Waveform<Ethernet64b66bSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class Ethernet64b66bDecoder : public Filter
 {

--- a/scopeprotocols/Ethernet64b66bDecoder.h
+++ b/scopeprotocols/Ethernet64b66bDecoder.h
@@ -63,9 +63,6 @@ class Ethernet64b66bDecoder : public Filter
 public:
 	Ethernet64b66bDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/EthernetAutonegotiationDecoder.cpp
+++ b/scopeprotocols/EthernetAutonegotiationDecoder.cpp
@@ -159,7 +159,7 @@ void EthernetAutonegotiationDecoder::Refresh()
 
 Gdk::Color EthernetAutonegotiationDecoder::GetColor(size_t /*i*/, size_t /*stream*/)
 {
-	return m_standardColors[COLOR_DATA];
+	return StandardColors::colors[StandardColors::COLOR_DATA];
 }
 
 string EthernetAutonegotiationDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/EthernetAutonegotiationDecoder.cpp
+++ b/scopeprotocols/EthernetAutonegotiationDecoder.cpp
@@ -157,20 +157,14 @@ void EthernetAutonegotiationDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color EthernetAutonegotiationDecoder::GetColor(size_t /*i*/, size_t /*stream*/)
+Gdk::Color EthernetAutonegotiationWaveform::GetColor(size_t /*i*/)
 {
 	return StandardColors::colors[StandardColors::COLOR_DATA];
 }
 
-string EthernetAutonegotiationDecoder::GetText(size_t i, size_t /*stream*/)
+string EthernetAutonegotiationWaveform::GetText(size_t i)
 {
-	auto data = dynamic_cast<EthernetAutonegotiationWaveform*>(GetData(0));
-	if(data == NULL)
-		return "";
-	if(i >= data->m_samples.size())
-		return "";
-
-	auto s = data->m_samples[i];
+	auto s = m_samples[i];
 	unsigned int sel = s & 0x1f;
 	unsigned int ability = (s >> 5) & 0x7f;
 	bool xnp = (s >> 12) & 1;

--- a/scopeprotocols/EthernetAutonegotiationDecoder.h
+++ b/scopeprotocols/EthernetAutonegotiationDecoder.h
@@ -36,7 +36,13 @@
 #ifndef EthernetAutonegotiationDecoder_h
 #define EthernetAutonegotiationDecoder_h
 
-typedef Waveform<uint16_t> EthernetAutonegotiationWaveform;
+class EthernetAutonegotiationWaveform : public Waveform<uint16_t>
+{
+public:
+	EthernetAutonegotiationWaveform () : Waveform<uint16_t>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class EthernetAutonegotiationDecoder : public Filter
 {

--- a/scopeprotocols/EthernetAutonegotiationDecoder.h
+++ b/scopeprotocols/EthernetAutonegotiationDecoder.h
@@ -43,9 +43,6 @@ class EthernetAutonegotiationDecoder : public Filter
 public:
 	EthernetAutonegotiationDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/EthernetProtocolDecoder.cpp
+++ b/scopeprotocols/EthernetProtocolDecoder.cpp
@@ -498,15 +498,9 @@ void EthernetProtocolDecoder::BytesToFrames(
 	delete pack;
 }
 
-Gdk::Color EthernetProtocolDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color EthernetWaveform::GetColor(size_t i)
 {
-	auto data = dynamic_cast<EthernetWaveform*>(GetData(0));
-	if(data == NULL)
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-	if(i >= data->m_samples.size())
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-
-	switch(data->m_samples[i].m_type)
+	switch(m_samples[i].m_type)
 	{
 		//Preamble/SFD: gray (not interesting)
 		case EthernetFrameSegment::TYPE_INBAND_STATUS:
@@ -542,17 +536,11 @@ Gdk::Color EthernetProtocolDecoder::GetColor(size_t i, size_t /*stream*/)
 	}
 }
 
-string EthernetProtocolDecoder::GetText(size_t i, size_t /*stream*/)
+string EthernetWaveform::GetText(size_t i)
 {
-	auto data = dynamic_cast<EthernetWaveform*>(GetData(0));
-	if(data == NULL)
-		return "";
-	if(i >= data->m_samples.size())
-		return "";
-
 	char tmp[128];
 
-	auto sample = data->m_samples[i];
+	auto sample = m_samples[i];
 	switch(sample.m_type)
 	{
 		case EthernetFrameSegment::TYPE_PREAMBLE:
@@ -621,9 +609,9 @@ string EthernetProtocolDecoder::GetText(size_t i, size_t /*stream*/)
 				if(ethertype < 1500)
 				{
 					//Look at the next segment to get the payload
-					if((size_t)i+1 < data->m_samples.size())
+					if((size_t)i+1 < m_samples.size())
 					{
-						auto& next = data->m_samples[i+1];
+						auto& next = m_samples[i+1];
 						if(next.m_data[0] == 0x42)
 							type += "STP";
 						else

--- a/scopeprotocols/EthernetProtocolDecoder.cpp
+++ b/scopeprotocols/EthernetProtocolDecoder.cpp
@@ -502,9 +502,9 @@ Gdk::Color EthernetProtocolDecoder::GetColor(size_t i, size_t /*stream*/)
 {
 	auto data = dynamic_cast<EthernetWaveform*>(GetData(0));
 	if(data == NULL)
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 	if(i >= data->m_samples.size())
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 	switch(data->m_samples[i].m_type)
 	{
@@ -512,33 +512,33 @@ Gdk::Color EthernetProtocolDecoder::GetColor(size_t i, size_t /*stream*/)
 		case EthernetFrameSegment::TYPE_INBAND_STATUS:
 		case EthernetFrameSegment::TYPE_PREAMBLE:
 		case EthernetFrameSegment::TYPE_SFD:
-			return m_standardColors[COLOR_PREAMBLE];
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 		//MAC addresses (src or dest)
 		case EthernetFrameSegment::TYPE_DST_MAC:
 		case EthernetFrameSegment::TYPE_SRC_MAC:
-			return m_standardColors[COLOR_ADDRESS];
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 		//Control codes
 		case EthernetFrameSegment::TYPE_ETHERTYPE:
 		case EthernetFrameSegment::TYPE_VLAN_TAG:
-			return m_standardColors[COLOR_CONTROL];
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 		case EthernetFrameSegment::TYPE_FCS_GOOD:
-			return m_standardColors[COLOR_CHECKSUM_OK];
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 		case EthernetFrameSegment::TYPE_FCS_BAD:
-			return m_standardColors[COLOR_CHECKSUM_BAD];
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
 
 		//Signal has entirely disappeared, or fault condition reported
 		case EthernetFrameSegment::TYPE_NO_CARRIER:
 		case EthernetFrameSegment::TYPE_REMOTE_FAULT:
 		case EthernetFrameSegment::TYPE_LOCAL_FAULT:
 		case EthernetFrameSegment::TYPE_LINK_INTERRUPTION:
-			return m_standardColors[COLOR_ERROR];
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 		//Payload
 		default:
-			return m_standardColors[COLOR_DATA];
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 	}
 }
 

--- a/scopeprotocols/EthernetProtocolDecoder.h
+++ b/scopeprotocols/EthernetProtocolDecoder.h
@@ -85,9 +85,6 @@ public:
 	EthernetProtocolDecoder(const std::string& color);
 	virtual ~EthernetProtocolDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
 
 	virtual std::vector<std::string> GetHeaders();

--- a/scopeprotocols/EthernetProtocolDecoder.h
+++ b/scopeprotocols/EthernetProtocolDecoder.h
@@ -77,7 +77,13 @@ public:
 	}
 };
 
-typedef Waveform<EthernetFrameSegment> EthernetWaveform;
+class EthernetWaveform : public Waveform<EthernetFrameSegment>
+{
+public:
+	EthernetWaveform () : Waveform<EthernetFrameSegment>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class EthernetProtocolDecoder : public PacketDecoder
 {

--- a/scopeprotocols/HyperRAMDecoder.cpp
+++ b/scopeprotocols/HyperRAMDecoder.cpp
@@ -379,23 +379,23 @@ Gdk::Color HyperRAMDecoder::GetColor(size_t i, size_t /*stream*/)
 		{
 			case HyperRAMSymbol::TYPE_SELECT:
 			case HyperRAMSymbol::TYPE_DESELECT:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case HyperRAMSymbol::TYPE_CA:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case HyperRAMSymbol::TYPE_WAIT:
-				return m_standardColors[COLOR_IDLE];
+				return StandardColors::colors[StandardColors::COLOR_IDLE];
 
 			case HyperRAMSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case HyperRAMSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string HyperRAMDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/HyperRAMDecoder.cpp
+++ b/scopeprotocols/HyperRAMDecoder.cpp
@@ -369,70 +369,60 @@ struct HyperRAMDecoder::CA HyperRAMDecoder::DecodeCA(uint64_t data)
 	};
 }
 
-Gdk::Color HyperRAMDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color HyperRAMWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<HyperRAMWaveform*>(GetData(0));
-	if(capture != NULL)
+	const HyperRAMSymbol& s = m_samples[i];
+	switch(s.m_stype)
 	{
-		const HyperRAMSymbol& s = capture->m_samples[i];
-		switch(s.m_stype)
-		{
-			case HyperRAMSymbol::TYPE_SELECT:
-			case HyperRAMSymbol::TYPE_DESELECT:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+		case HyperRAMSymbol::TYPE_SELECT:
+		case HyperRAMSymbol::TYPE_DESELECT:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case HyperRAMSymbol::TYPE_CA:
-				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
+		case HyperRAMSymbol::TYPE_CA:
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
-			case HyperRAMSymbol::TYPE_WAIT:
-				return StandardColors::colors[StandardColors::COLOR_IDLE];
+		case HyperRAMSymbol::TYPE_WAIT:
+			return StandardColors::colors[StandardColors::COLOR_IDLE];
 
-			case HyperRAMSymbol::TYPE_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
+		case HyperRAMSymbol::TYPE_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-			case HyperRAMSymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case HyperRAMSymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string HyperRAMDecoder::GetText(size_t i, size_t /*stream*/)
+string HyperRAMWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<HyperRAMWaveform*>(GetData(0));
-	if(capture != NULL)
+	const HyperRAMSymbol& s = m_samples[i];
+	char tmp[32];
+	struct HyperRAMDecoder::CA ca;
+	const char* rw;
+	const char* space;
+	uint32_t addr;
+	const char* burst;
+	switch(s.m_stype)
 	{
-		const HyperRAMSymbol& s = capture->m_samples[i];
-		char tmp[32];
-		struct HyperRAMDecoder::CA ca;
-		const char* rw;
-		const char* space;
-		uint32_t addr;
-		const char* burst;
-		switch(s.m_stype)
-		{
-			case HyperRAMSymbol::TYPE_SELECT:
-				return "SELECT";
-			case HyperRAMSymbol::TYPE_DESELECT:
-				return "DESELECT";
-			case HyperRAMSymbol::TYPE_CA:
-				ca    = DecodeCA(s.m_data);
-				rw    = ca.read ? "Read" : "Write";
-				space = ca.register_space ? "reg" : "mem";
-				addr  = ca.address;
-				burst = ca.linear ? "linear" : "wrapped";
-				snprintf(tmp, sizeof(tmp), "%s %s %08x %s", rw, space, addr, burst);
-				return string(tmp);
-			case HyperRAMSymbol::TYPE_WAIT:
-				return "WAIT";
-			case HyperRAMSymbol::TYPE_DATA:
-				snprintf(tmp, sizeof(tmp), "%02x", (uint8_t)s.m_data);
-				return string(tmp);
-			case HyperRAMSymbol::TYPE_ERROR:
-			default:
-				return "ERROR";
-		}
+		case HyperRAMSymbol::TYPE_SELECT:
+			return "SELECT";
+		case HyperRAMSymbol::TYPE_DESELECT:
+			return "DESELECT";
+		case HyperRAMSymbol::TYPE_CA:
+			ca    = HyperRAMDecoder::DecodeCA(s.m_data);
+			rw    = ca.read ? "Read" : "Write";
+			space = ca.register_space ? "reg" : "mem";
+			addr  = ca.address;
+			burst = ca.linear ? "linear" : "wrapped";
+			snprintf(tmp, sizeof(tmp), "%s %s %08x %s", rw, space, addr, burst);
+			return string(tmp);
+		case HyperRAMSymbol::TYPE_WAIT:
+			return "WAIT";
+		case HyperRAMSymbol::TYPE_DATA:
+			snprintf(tmp, sizeof(tmp), "%02x", (uint8_t)s.m_data);
+			return string(tmp);
+		case HyperRAMSymbol::TYPE_ERROR:
+		default:
+			return "ERROR";
 	}
-	return "";
 }

--- a/scopeprotocols/HyperRAMDecoder.h
+++ b/scopeprotocols/HyperRAMDecoder.h
@@ -66,7 +66,13 @@ public:
 	}
 };
 
-typedef Waveform<HyperRAMSymbol> HyperRAMWaveform;
+class HyperRAMWaveform : public Waveform<HyperRAMSymbol>
+{
+public:
+	HyperRAMWaveform () : Waveform<HyperRAMSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class HyperRAMDecoder : public Filter
 {
@@ -81,7 +87,6 @@ public:
 
 	PROTOCOL_DECODER_INITPROC(HyperRAMDecoder)
 
-private:
 	struct CA
 	{
 		uint32_t address;
@@ -89,7 +94,7 @@ private:
 		bool register_space;
 		bool linear;
 	};
-	struct CA DecodeCA(uint64_t data);
+	static struct CA DecodeCA(uint64_t data);
 
 protected:
 	std::string m_latencyname;

--- a/scopeprotocols/HyperRAMDecoder.h
+++ b/scopeprotocols/HyperRAMDecoder.h
@@ -73,8 +73,8 @@ class HyperRAMDecoder : public Filter
 public:
 	HyperRAMDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	void Refresh() override;
 

--- a/scopeprotocols/HyperRAMDecoder.h
+++ b/scopeprotocols/HyperRAMDecoder.h
@@ -73,9 +73,6 @@ class HyperRAMDecoder : public Filter
 public:
 	HyperRAMDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	void Refresh() override;
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/I2CDecoder.cpp
+++ b/scopeprotocols/I2CDecoder.cpp
@@ -220,25 +220,25 @@ Gdk::Color I2CDecoder::GetColor(size_t i, size_t /*stream*/)
 		switch(s.m_stype)
 		{
 			case I2CSymbol::TYPE_ERROR:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 			case I2CSymbol::TYPE_ADDRESS:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 			case I2CSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case I2CSymbol::TYPE_ACK:
 				if(s.m_data)
-					return m_standardColors[COLOR_IDLE];
+					return StandardColors::colors[StandardColors::COLOR_IDLE];
 				else
-					return m_standardColors[COLOR_CHECKSUM_OK];
+					return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 			default:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 		}
 	}
 
 	//error
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string I2CDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/I2CDecoder.cpp
+++ b/scopeprotocols/I2CDecoder.cpp
@@ -210,77 +210,65 @@ void I2CDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color I2CDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color I2CWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<I2CWaveform*>(GetData(0));
-	if(capture != NULL)
+	const I2CSymbol& s = m_samples[i];
+
+	switch(s.m_stype)
 	{
-		const I2CSymbol& s = capture->m_samples[i];
+		case I2CSymbol::TYPE_ERROR:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
+		case I2CSymbol::TYPE_ADDRESS:
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
+		case I2CSymbol::TYPE_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-		switch(s.m_stype)
-		{
-			case I2CSymbol::TYPE_ERROR:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-			case I2CSymbol::TYPE_ADDRESS:
-				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
-			case I2CSymbol::TYPE_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
+		case I2CSymbol::TYPE_ACK:
+			if(s.m_data)
+				return StandardColors::colors[StandardColors::COLOR_IDLE];
+			else
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
-			case I2CSymbol::TYPE_ACK:
-				if(s.m_data)
-					return StandardColors::colors[StandardColors::COLOR_IDLE];
-				else
-					return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
-
-			default:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
-		}
+		default:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 	}
-
-	//error
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string I2CDecoder::GetText(size_t i, size_t /*stream*/)
+string I2CWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<I2CWaveform*>(GetData(0));
-	if(capture != NULL)
-	{
-		const I2CSymbol& s = capture->m_samples[i];
+	const I2CSymbol& s = m_samples[i];
 
-		char tmp[32];
-		switch(s.m_stype)
-		{
-			case I2CSymbol::TYPE_NONE:
-			case I2CSymbol::TYPE_ERROR:
-				snprintf(tmp, sizeof(tmp), "ERR");
-				break;
-			case I2CSymbol::TYPE_START:
-				snprintf(tmp, sizeof(tmp), "START");
-				break;
-			case I2CSymbol::TYPE_RESTART:
-				snprintf(tmp, sizeof(tmp), "RESTART");
-				break;
-			case I2CSymbol::TYPE_STOP:
-				snprintf(tmp, sizeof(tmp), "STOP");
-				break;
-			case I2CSymbol::TYPE_ACK:
-				if(s.m_data)
-					snprintf(tmp, sizeof(tmp), "NAK");
-				else
-					snprintf(tmp, sizeof(tmp), "ACK");
-				break;
-			case I2CSymbol::TYPE_ADDRESS:
-				if(s.m_data & 1)
-					snprintf(tmp, sizeof(tmp), "R:%02x", s.m_data & 0xfe);
-				else
-					snprintf(tmp, sizeof(tmp), "W:%02x", s.m_data & 0xfe);
-				break;
-			case I2CSymbol::TYPE_DATA:
-				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				break;
-		}
-		return string(tmp);
+	char tmp[32];
+	switch(s.m_stype)
+	{
+		case I2CSymbol::TYPE_NONE:
+		case I2CSymbol::TYPE_ERROR:
+			snprintf(tmp, sizeof(tmp), "ERR");
+			break;
+		case I2CSymbol::TYPE_START:
+			snprintf(tmp, sizeof(tmp), "START");
+			break;
+		case I2CSymbol::TYPE_RESTART:
+			snprintf(tmp, sizeof(tmp), "RESTART");
+			break;
+		case I2CSymbol::TYPE_STOP:
+			snprintf(tmp, sizeof(tmp), "STOP");
+			break;
+		case I2CSymbol::TYPE_ACK:
+			if(s.m_data)
+				snprintf(tmp, sizeof(tmp), "NAK");
+			else
+				snprintf(tmp, sizeof(tmp), "ACK");
+			break;
+		case I2CSymbol::TYPE_ADDRESS:
+			if(s.m_data & 1)
+				snprintf(tmp, sizeof(tmp), "R:%02x", s.m_data & 0xfe);
+			else
+				snprintf(tmp, sizeof(tmp), "W:%02x", s.m_data & 0xfe);
+			break;
+		case I2CSymbol::TYPE_DATA:
+			snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			break;
 	}
-	return "";
+	return string(tmp);
 }

--- a/scopeprotocols/I2CDecoder.h
+++ b/scopeprotocols/I2CDecoder.h
@@ -75,9 +75,6 @@ class I2CDecoder : public Filter
 public:
 	I2CDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/I2CDecoder.h
+++ b/scopeprotocols/I2CDecoder.h
@@ -68,7 +68,13 @@ public:
 	}
 };
 
-typedef Waveform<I2CSymbol> I2CWaveform;
+class I2CWaveform : public Waveform<I2CSymbol>
+{
+public:
+	I2CWaveform () : Waveform<I2CSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class I2CDecoder : public Filter
 {

--- a/scopeprotocols/I2CDecoder.h
+++ b/scopeprotocols/I2CDecoder.h
@@ -75,8 +75,8 @@ class I2CDecoder : public Filter
 public:
 	I2CDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/I2CEepromDecoder.cpp
+++ b/scopeprotocols/I2CEepromDecoder.cpp
@@ -511,26 +511,26 @@ Gdk::Color I2CEepromDecoder::GetColor(size_t i, size_t /*stream*/)
 		{
 			case I2CEepromSymbol::TYPE_SELECT_READ:
 			case I2CEepromSymbol::TYPE_SELECT_WRITE:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case I2CEepromSymbol::TYPE_POLL_BUSY:
-				return m_standardColors[COLOR_IDLE];
+				return StandardColors::colors[StandardColors::COLOR_IDLE];
 
 			case I2CEepromSymbol::TYPE_POLL_OK:
-				return m_standardColors[COLOR_CHECKSUM_OK];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 			case I2CEepromSymbol::TYPE_ADDRESS:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case I2CEepromSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string I2CEepromDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/I2CEepromDecoder.h
+++ b/scopeprotocols/I2CEepromDecoder.h
@@ -68,7 +68,16 @@ public:
 	}
 };
 
-typedef Waveform<I2CEepromSymbol> I2CEepromWaveform;
+class I2CEepromWaveform : public Waveform<I2CEepromSymbol>
+{
+public:
+	I2CEepromWaveform (FilterParameter& raw_bits) : Waveform<I2CEepromSymbol>(), m_raw_bits(raw_bits) {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+
+private:
+	FilterParameter& m_raw_bits;
+};
 
 class I2CEepromDecoder : public PacketDecoder
 {

--- a/scopeprotocols/I2CEepromDecoder.h
+++ b/scopeprotocols/I2CEepromDecoder.h
@@ -75,9 +75,6 @@ class I2CEepromDecoder : public PacketDecoder
 public:
 	I2CEepromDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/IBM8b10bDecoder.cpp
+++ b/scopeprotocols/IBM8b10bDecoder.cpp
@@ -49,10 +49,17 @@ IBM8b10bDecoder::IBM8b10bDecoder(const string& color)
 	CreateInput("clk");
 
 	m_displayformat = "Display Format";
-	m_parameters[m_displayformat] = FilterParameter(FilterParameter::TYPE_ENUM, Unit(Unit::UNIT_COUNTS));
-	m_parameters[m_displayformat].AddEnumValue("Dotted (K28.5 D21.5)", FORMAT_DOTTED);
-	m_parameters[m_displayformat].AddEnumValue("Hex (K.bc b5)", FORMAT_HEX);
-	m_parameters[m_displayformat].SetIntVal(FORMAT_DOTTED);
+	m_parameters[m_displayformat] = MakeIBM8b10bDisplayFormatParameter();
+}
+
+FilterParameter IBM8b10bDecoder::MakeIBM8b10bDisplayFormatParameter()
+{
+	auto f = FilterParameter(FilterParameter::TYPE_ENUM, Unit(Unit::UNIT_COUNTS));
+	f.AddEnumValue("Dotted (K28.5 D21.5)", FORMAT_DOTTED);
+	f.AddEnumValue("Hex (K.bc b5)", FORMAT_HEX);
+	f.SetIntVal(FORMAT_DOTTED);
+
+	return f;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/scopeprotocols/IBM8b10bDecoder.cpp
+++ b/scopeprotocols/IBM8b10bDecoder.cpp
@@ -43,7 +43,6 @@ using namespace std;
 
 IBM8b10bDecoder::IBM8b10bDecoder(const string& color)
 	: Filter(color, CAT_SERIAL)
-	, m_cachedDisplayFormat(FORMAT_DOTTED)
 {
 	AddProtocolStream("data");
 	CreateInput("data");
@@ -83,8 +82,6 @@ void IBM8b10bDecoder::Refresh()
 	LogTrace("IBM8b10bDecoder::Refresh\n");
 	LogIndenter li;
 
-	m_cachedDisplayFormat = (DisplayFormat) m_parameters[m_displayformat].GetIntVal();
-
 	if(!VerifyAllInputsOK())
 	{
 		SetData(NULL, 0);
@@ -96,7 +93,7 @@ void IBM8b10bDecoder::Refresh()
 	auto clkin = GetDigitalInputWaveform(1);
 
 	//Create the capture
-	auto cap = new IBM8b10bWaveform;
+	auto cap = new IBM8b10bWaveform(m_parameters[m_displayformat]);
 	cap->m_timescale = 1;
 	cap->m_startTimestamp = din->m_startTimestamp;
 	cap->m_startFemtoseconds = din->m_startFemtoseconds;
@@ -367,65 +364,57 @@ void IBM8b10bDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color IBM8b10bDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color IBM8b10bWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<IBM8b10bWaveform*>(GetData(0));
-	if(capture != NULL)
-	{
-		const IBM8b10bSymbol& s = capture->m_samples[i];
+	const IBM8b10bSymbol& s = m_samples[i];
 
-		if(s.m_error)
-			return StandardColors::colors[StandardColors::COLOR_ERROR];
-		else if(s.m_control)
-			return StandardColors::colors[StandardColors::COLOR_CONTROL];
-		else
-			return StandardColors::colors[StandardColors::COLOR_DATA];
-	}
-
-	//error
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
+	if(s.m_error)
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
+	else if(s.m_control)
+		return StandardColors::colors[StandardColors::COLOR_CONTROL];
+	else
+		return StandardColors::colors[StandardColors::COLOR_DATA];
 }
 
-string IBM8b10bDecoder::GetText(size_t i, size_t /*stream*/)
+string IBM8b10bWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<IBM8b10bWaveform*>(GetData(0));
-	if(capture != NULL)
+	const IBM8b10bSymbol& s = m_samples[i];
+
+	IBM8b10bDecoder::DisplayFormat cachedDisplayFormat = (IBM8b10bDecoder::DisplayFormat) m_displayformat.GetIntVal();
+
+	unsigned int right = s.m_data >> 5;
+	unsigned int left = s.m_data & 0x1F;
+
+	char tmp[32];
+	if(s.m_error)
+		return "ERROR";
+	else
 	{
-		const IBM8b10bSymbol& s = capture->m_samples[i];
+		//Dotted format
+		if(cachedDisplayFormat == IBM8b10bDecoder::FORMAT_DOTTED)
+		{
+			if(s.m_control)
+				snprintf(tmp, sizeof(tmp), "K%u.%u", left, right);
+			else
+				snprintf(tmp, sizeof(tmp), "D%u.%u", left, right);
 
-		unsigned int right = s.m_data >> 5;
-		unsigned int left = s.m_data & 0x1F;
+			if(s.m_disparity < 0)
+				return string(tmp) + "-";
+			else
+				return string(tmp) + "+";
+		}
 
-		char tmp[32];
-		if(s.m_error)
-			return "ERROR";
+		//Hex format
 		else
 		{
-			//Dotted format
-			if(m_cachedDisplayFormat == FORMAT_DOTTED)
-			{
-				if(s.m_control)
-					snprintf(tmp, sizeof(tmp), "K%u.%u", left, right);
-				else
-					snprintf(tmp, sizeof(tmp), "D%u.%u", left, right);
-
-				if(s.m_disparity < 0)
-					return string(tmp) + "-";
-				else
-					return string(tmp) + "+";
-			}
-
-			//Hex format
+			if(s.m_control)
+				snprintf(tmp, sizeof(tmp), "K.%02x", s.m_data);
 			else
-			{
-				if(s.m_control)
-					snprintf(tmp, sizeof(tmp), "K.%02x", s.m_data);
-				else
-					snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				return string(tmp);
-			}
+				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			return string(tmp);
 		}
 	}
+
 	return "";
 }
 

--- a/scopeprotocols/IBM8b10bDecoder.cpp
+++ b/scopeprotocols/IBM8b10bDecoder.cpp
@@ -375,15 +375,15 @@ Gdk::Color IBM8b10bDecoder::GetColor(size_t i, size_t /*stream*/)
 		const IBM8b10bSymbol& s = capture->m_samples[i];
 
 		if(s.m_error)
-			return m_standardColors[COLOR_ERROR];
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 		else if(s.m_control)
-			return m_standardColors[COLOR_CONTROL];
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 		else
-			return m_standardColors[COLOR_DATA];
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 	}
 
 	//error
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string IBM8b10bDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/IBM8b10bDecoder.h
+++ b/scopeprotocols/IBM8b10bDecoder.h
@@ -70,8 +70,8 @@ class IBM8b10bDecoder : public Filter
 public:
 	IBM8b10bDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/IBM8b10bDecoder.h
+++ b/scopeprotocols/IBM8b10bDecoder.h
@@ -63,7 +63,15 @@ public:
 	}
 };
 
-typedef Waveform<IBM8b10bSymbol> IBM8b10bWaveform;
+class IBM8b10bWaveform : public Waveform<IBM8b10bSymbol>
+{
+public:
+	IBM8b10bWaveform (FilterParameter& displayformat) : Waveform<IBM8b10bSymbol>(), m_displayformat(displayformat) {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+
+	FilterParameter& m_displayformat;
+};
 
 class IBM8b10bDecoder : public Filter
 {
@@ -80,7 +88,7 @@ public:
 	{
 		FORMAT_DOTTED,
 		FORMAT_HEX
-	} m_cachedDisplayFormat;
+	};
 
 	PROTOCOL_DECODER_INITPROC(IBM8b10bDecoder)
 

--- a/scopeprotocols/IBM8b10bDecoder.h
+++ b/scopeprotocols/IBM8b10bDecoder.h
@@ -78,6 +78,8 @@ class IBM8b10bDecoder : public Filter
 public:
 	IBM8b10bDecoder(const std::string& color);
 
+	static FilterParameter MakeIBM8b10bDisplayFormatParameter();
+
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/IBM8b10bDecoder.h
+++ b/scopeprotocols/IBM8b10bDecoder.h
@@ -70,9 +70,6 @@ class IBM8b10bDecoder : public Filter
 public:
 	IBM8b10bDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/IPv4Decoder.cpp
+++ b/scopeprotocols/IPv4Decoder.cpp
@@ -406,15 +406,15 @@ Gdk::Color IPv4Decoder::GetColor(size_t i, size_t /*stream*/)
 {
 	auto data = dynamic_cast<IPv4Waveform*>(GetData(0));
 	if(data == NULL)
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 	if(i >= data->m_samples.size())
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 	switch(data->m_samples[i].m_type)
 	{
 		case IPv4Symbol::TYPE_VERSION:
 		case IPv4Symbol::TYPE_HEADER_LEN:
-			return m_standardColors[COLOR_PREAMBLE];
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 		case IPv4Symbol::TYPE_FLAGS:
 		case IPv4Symbol::TYPE_DIFFSERV:
@@ -424,22 +424,22 @@ Gdk::Color IPv4Decoder::GetColor(size_t i, size_t /*stream*/)
 		case IPv4Symbol::TYPE_TTL:
 		case IPv4Symbol::TYPE_PROTOCOL:
 		case IPv4Symbol::TYPE_OPTIONS:
-			return m_standardColors[COLOR_CONTROL];
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 		//TODO: properly verify checksum
 		case IPv4Symbol::TYPE_HEADER_CHECKSUM:
-			return m_standardColors[COLOR_CHECKSUM_OK];
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 		case IPv4Symbol::TYPE_SOURCE_IP:
 		case IPv4Symbol::TYPE_DEST_IP:
-			return m_standardColors[COLOR_ADDRESS];
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 		case IPv4Symbol::TYPE_DATA:
-			return m_standardColors[COLOR_DATA];
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
 		case IPv4Symbol::TYPE_ERROR:
 		default:
-			return m_standardColors[COLOR_ERROR];
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
 }
 

--- a/scopeprotocols/IPv4Decoder.cpp
+++ b/scopeprotocols/IPv4Decoder.cpp
@@ -402,15 +402,9 @@ void IPv4Decoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color IPv4Decoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color IPv4Waveform::GetColor(size_t i)
 {
-	auto data = dynamic_cast<IPv4Waveform*>(GetData(0));
-	if(data == NULL)
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-	if(i >= data->m_samples.size())
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-
-	switch(data->m_samples[i].m_type)
+	switch(m_samples[i].m_type)
 	{
 		case IPv4Symbol::TYPE_VERSION:
 		case IPv4Symbol::TYPE_HEADER_LEN:
@@ -443,17 +437,11 @@ Gdk::Color IPv4Decoder::GetColor(size_t i, size_t /*stream*/)
 	}
 }
 
-string IPv4Decoder::GetText(size_t i, size_t /*stream*/)
+string IPv4Waveform::GetText(size_t i)
 {
-	auto data = dynamic_cast<IPv4Waveform*>(GetData(0));
-	if(data == NULL)
-		return "";
-	if(i >= data->m_samples.size())
-		return "";
-
 	char tmp[128];
 
-	auto sample = data->m_samples[i];
+	auto sample = m_samples[i];
 	switch(sample.m_type)
 	{
 		case IPv4Symbol::TYPE_VERSION:

--- a/scopeprotocols/IPv4Decoder.h
+++ b/scopeprotocols/IPv4Decoder.h
@@ -80,9 +80,6 @@ class IPv4Decoder : public Filter
 public:
 	IPv4Decoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/IPv4Decoder.h
+++ b/scopeprotocols/IPv4Decoder.h
@@ -73,7 +73,13 @@ public:
 	}
 };
 
-typedef Waveform<IPv4Symbol> IPv4Waveform;
+class IPv4Waveform : public Waveform<IPv4Symbol>
+{
+public:
+	IPv4Waveform () : Waveform<IPv4Symbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class IPv4Decoder : public Filter
 {

--- a/scopeprotocols/IPv4Decoder.h
+++ b/scopeprotocols/IPv4Decoder.h
@@ -80,8 +80,8 @@ class IPv4Decoder : public Filter
 public:
 	IPv4Decoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/JtagDecoder.cpp
+++ b/scopeprotocols/JtagDecoder.cpp
@@ -342,21 +342,21 @@ Gdk::Color JtagDecoder::GetColor(size_t i, size_t /*stream*/)
 			case JtagSymbol::UNKNOWN_2:
 			case JtagSymbol::UNKNOWN_3:
 			case JtagSymbol::UNKNOWN_4:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 			//Data characters
 			case JtagSymbol::SHIFT_IR:
 			case JtagSymbol::SHIFT_DR:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			//intermediate states
 			default:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 		}
 	}
 
 	//error
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string JtagDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/JtagDecoder.h
+++ b/scopeprotocols/JtagDecoder.h
@@ -101,8 +101,8 @@ class JtagDecoder : public PacketDecoder
 public:
 	JtagDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/JtagDecoder.h
+++ b/scopeprotocols/JtagDecoder.h
@@ -101,9 +101,6 @@ class JtagDecoder : public PacketDecoder
 public:
 	JtagDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/JtagDecoder.h
+++ b/scopeprotocols/JtagDecoder.h
@@ -94,7 +94,13 @@ public:
 	uint8_t m_len;
 };
 
-typedef Waveform<JtagSymbol> JtagWaveform;
+class JtagWaveform : public Waveform<JtagSymbol>
+{
+public:
+	JtagWaveform () : Waveform<JtagSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class JtagDecoder : public PacketDecoder
 {

--- a/scopeprotocols/MDIODecoder.cpp
+++ b/scopeprotocols/MDIODecoder.cpp
@@ -631,23 +631,23 @@ Gdk::Color MDIODecoder::GetColor(size_t i, size_t /*stream*/)
 			case MDIOSymbol::TYPE_PREAMBLE:
 			case MDIOSymbol::TYPE_START:
 			case MDIOSymbol::TYPE_TURN:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case MDIOSymbol::TYPE_OP:
 				if( (s.m_data == 1) || (s.m_data == 2) )
-					return m_standardColors[COLOR_CONTROL];
+					return StandardColors::colors[StandardColors::COLOR_CONTROL];
 				else
-					return m_standardColors[COLOR_ERROR];
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 			case MDIOSymbol::TYPE_PHYADDR:
 			case MDIOSymbol::TYPE_REGADDR:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case MDIOSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case MDIOSymbol::TYPE_ERROR:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 

--- a/scopeprotocols/MDIODecoder.h
+++ b/scopeprotocols/MDIODecoder.h
@@ -77,9 +77,6 @@ class MDIODecoder : public PacketDecoder
 public:
 	MDIODecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/MDIODecoder.h
+++ b/scopeprotocols/MDIODecoder.h
@@ -70,7 +70,13 @@ public:
 	}
 };
 
-typedef Waveform<MDIOSymbol> MDIOWaveform;
+class MDIOWaveform : public Waveform<MDIOSymbol>
+{
+public:
+	MDIOWaveform () : Waveform<MDIOSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class MDIODecoder : public PacketDecoder
 {

--- a/scopeprotocols/MDIODecoder.h
+++ b/scopeprotocols/MDIODecoder.h
@@ -77,8 +77,8 @@ class MDIODecoder : public PacketDecoder
 public:
 	MDIODecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/MilStd1553Decoder.cpp
+++ b/scopeprotocols/MilStd1553Decoder.cpp
@@ -684,38 +684,38 @@ Gdk::Color MilStd1553Decoder::GetColor(size_t i, size_t /*stream*/)
 			case MilStd1553Symbol::TYPE_SYNC_CTRL_STAT:
 			case MilStd1553Symbol::TYPE_SYNC_DATA:
 			case MilStd1553Symbol::TYPE_TURNAROUND:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case MilStd1553Symbol::TYPE_RT_ADDR:
 			case MilStd1553Symbol::TYPE_SUB_ADDR:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case MilStd1553Symbol::TYPE_DIRECTION:
 			case MilStd1553Symbol::TYPE_LENGTH:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case MilStd1553Symbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case MilStd1553Symbol::TYPE_PARITY_OK:
 			case MilStd1553Symbol::TYPE_MSG_OK:
-				return m_standardColors[COLOR_CHECKSUM_OK];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 			case MilStd1553Symbol::TYPE_STATUS:
 				if(s.m_data & MilStd1553Symbol::STATUS_ANY_FAULT)
-					return m_standardColors[COLOR_ERROR];
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
 				else
-					return m_standardColors[COLOR_CONTROL];
+					return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case MilStd1553Symbol::TYPE_PARITY_BAD:
 			case MilStd1553Symbol::TYPE_MSG_ERR:
 			case MilStd1553Symbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string MilStd1553Decoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/MilStd1553Decoder.h
+++ b/scopeprotocols/MilStd1553Decoder.h
@@ -100,9 +100,6 @@ public:
 	MilStd1553Decoder(const std::string& color);
 	virtual ~MilStd1553Decoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 	static std::string GetProtocolName();
 

--- a/scopeprotocols/MilStd1553Decoder.h
+++ b/scopeprotocols/MilStd1553Decoder.h
@@ -92,7 +92,13 @@ public:
 	}
 };
 
-typedef Waveform<MilStd1553Symbol> MilStd1553Waveform;
+class MilStd1553Waveform : public Waveform<MilStd1553Symbol>
+{
+public:
+	MilStd1553Waveform () : Waveform<MilStd1553Symbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class MilStd1553Decoder : public PacketDecoder
 {

--- a/scopeprotocols/MilStd1553Decoder.h
+++ b/scopeprotocols/MilStd1553Decoder.h
@@ -100,8 +100,8 @@ public:
 	MilStd1553Decoder(const std::string& color);
 	virtual ~MilStd1553Decoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 	static std::string GetProtocolName();

--- a/scopeprotocols/OneWireDecoder.cpp
+++ b/scopeprotocols/OneWireDecoder.cpp
@@ -276,23 +276,23 @@ Gdk::Color OneWireDecoder::GetColor(size_t i, size_t /*stream*/)
 		{
 			case OneWireSymbol::TYPE_RESET:
 				if(s.m_data == 1)
-					return m_standardColors[COLOR_ERROR];
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
 				else
-					return m_standardColors[COLOR_CONTROL];
+					return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case OneWireSymbol::TYPE_PRESENCE:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case OneWireSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case OneWireSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string OneWireDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/OneWireDecoder.cpp
+++ b/scopeprotocols/OneWireDecoder.cpp
@@ -265,65 +265,53 @@ void OneWireDecoder::Refresh()
 	}
 }
 
-Gdk::Color OneWireDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color OneWireWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<OneWireWaveform*>(GetData(0));
-	if(capture != NULL)
+	const OneWireSymbol& s = m_samples[i];
+
+	switch(s.m_stype)
 	{
-		const OneWireSymbol& s = capture->m_samples[i];
-
-		switch(s.m_stype)
-		{
-			case OneWireSymbol::TYPE_RESET:
-				if(s.m_data == 1)
-					return StandardColors::colors[StandardColors::COLOR_ERROR];
-				else
-					return StandardColors::colors[StandardColors::COLOR_CONTROL];
-
-			case OneWireSymbol::TYPE_PRESENCE:
+		case OneWireSymbol::TYPE_RESET:
+			if(s.m_data == 1)
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
+			else
 				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case OneWireSymbol::TYPE_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
+		case OneWireSymbol::TYPE_PRESENCE:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case OneWireSymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case OneWireSymbol::TYPE_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
+
+		case OneWireSymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string OneWireDecoder::GetText(size_t i, size_t /*stream*/)
+string OneWireWaveform::GetText(size_t i)
 {
 	char tmp[32];
 
-	auto capture = dynamic_cast<OneWireWaveform*>(GetData(0));
-	if(capture != NULL)
+	const OneWireSymbol& s = m_samples[i];
+
+	switch(s.m_stype)
 	{
-		const OneWireSymbol& s = capture->m_samples[i];
+		case OneWireSymbol::TYPE_RESET:
+			if(s.m_data == 1)
+				return "RESET (too short)";
+			else
+				return "RESET";
 
-		switch(s.m_stype)
-		{
-			case OneWireSymbol::TYPE_RESET:
-				if(s.m_data == 1)
-					return "RESET (too short)";
-				else
-					return "RESET";
+		case OneWireSymbol::TYPE_DATA:
+			snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			return string(tmp);
 
-			case OneWireSymbol::TYPE_DATA:
-				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				return string(tmp);
+		case OneWireSymbol::TYPE_PRESENCE:
+			return "PRESENT";
 
-			case OneWireSymbol::TYPE_PRESENCE:
-				return "PRESENT";
-
-			case OneWireSymbol::TYPE_ERROR:
-			default:
-				return "ERROR";
-		}
+		case OneWireSymbol::TYPE_ERROR:
+		default:
+			return "ERROR";
 	}
-
-	return "";
 }

--- a/scopeprotocols/OneWireDecoder.h
+++ b/scopeprotocols/OneWireDecoder.h
@@ -72,8 +72,8 @@ public:
 	OneWireDecoder(const std::string& color);
 	virtual ~OneWireDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/OneWireDecoder.h
+++ b/scopeprotocols/OneWireDecoder.h
@@ -64,7 +64,13 @@ public:
 	}
 };
 
-typedef Waveform<OneWireSymbol> OneWireWaveform;
+class OneWireWaveform : public Waveform<OneWireSymbol>
+{
+public:
+	OneWireWaveform () : Waveform<OneWireSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class OneWireDecoder : public Filter
 {

--- a/scopeprotocols/OneWireDecoder.h
+++ b/scopeprotocols/OneWireDecoder.h
@@ -72,9 +72,6 @@ public:
 	OneWireDecoder(const std::string& color);
 	virtual ~OneWireDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/PCIe128b130bDecoder.cpp
+++ b/scopeprotocols/PCIe128b130bDecoder.cpp
@@ -217,54 +217,43 @@ void PCIe128b130bDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color PCIe128b130bDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color PCIe128b130bWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<PCIe128b130bWaveform*>(GetData(0));
-	if(capture != NULL)
+	const PCIe128b130bSymbol& s = m_samples[i];
+
+	switch(s.m_type)
 	{
-		const PCIe128b130bSymbol& s = capture->m_samples[i];
+		case PCIe128b130bSymbol::TYPE_SCRAMBLER_DESYNCED:
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
-		switch(s.m_type)
-		{
-			case PCIe128b130bSymbol::TYPE_SCRAMBLER_DESYNCED:
-				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
+		case PCIe128b130bSymbol::TYPE_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-			case PCIe128b130bSymbol::TYPE_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
+		case PCIe128b130bSymbol::TYPE_ORDERED_SET:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case PCIe128b130bSymbol::TYPE_ORDERED_SET:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
-
-			case PCIe128b130bSymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case PCIe128b130bSymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	//error
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string PCIe128b130bDecoder::GetText(size_t i, size_t /*stream*/)
+string PCIe128b130bWaveform::GetText(size_t i)
 {
 	string ret;
 
-	auto capture = dynamic_cast<PCIe128b130bWaveform*>(GetData(0));
-	if(capture != NULL)
+	const PCIe128b130bSymbol& s = m_samples[i];
+
+	if(s.m_type == PCIe128b130bSymbol::TYPE_SCRAMBLER_DESYNCED)
+		return "Scrambler desynced";
+	else if(s.m_type == PCIe128b130bSymbol::TYPE_ERROR)
+		return "ERROR";
+
+	char tmp[32];
+	for(size_t j=0; j<s.m_len; j++)
 	{
-		const PCIe128b130bSymbol& s = capture->m_samples[i];
-
-		if(s.m_type == PCIe128b130bSymbol::TYPE_SCRAMBLER_DESYNCED)
-			return "Scrambler desynced";
-		else if(s.m_type == PCIe128b130bSymbol::TYPE_ERROR)
-			return "ERROR";
-
-		char tmp[32];
-		for(size_t j=0; j<s.m_len; j++)
-		{
-			snprintf(tmp, sizeof(tmp), "%02x", s.m_data[j]);
-			ret += tmp;
-		}
+		snprintf(tmp, sizeof(tmp), "%02x", s.m_data[j]);
+		ret += tmp;
 	}
 
 	return ret;

--- a/scopeprotocols/PCIe128b130bDecoder.cpp
+++ b/scopeprotocols/PCIe128b130bDecoder.cpp
@@ -227,22 +227,22 @@ Gdk::Color PCIe128b130bDecoder::GetColor(size_t i, size_t /*stream*/)
 		switch(s.m_type)
 		{
 			case PCIe128b130bSymbol::TYPE_SCRAMBLER_DESYNCED:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case PCIe128b130bSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case PCIe128b130bSymbol::TYPE_ORDERED_SET:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case PCIe128b130bSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
 	//error
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string PCIe128b130bDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/PCIe128b130bDecoder.h
+++ b/scopeprotocols/PCIe128b130bDecoder.h
@@ -68,7 +68,13 @@ public:
 	}
 };
 
-typedef Waveform<PCIe128b130bSymbol> PCIe128b130bWaveform;
+class PCIe128b130bWaveform : public Waveform<PCIe128b130bSymbol>
+{
+public:
+	PCIe128b130bWaveform () : Waveform<PCIe128b130bSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class PCIe128b130bDecoder : public Filter
 {

--- a/scopeprotocols/PCIe128b130bDecoder.h
+++ b/scopeprotocols/PCIe128b130bDecoder.h
@@ -75,8 +75,8 @@ class PCIe128b130bDecoder : public Filter
 public:
 	PCIe128b130bDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/PCIe128b130bDecoder.h
+++ b/scopeprotocols/PCIe128b130bDecoder.h
@@ -75,9 +75,6 @@ class PCIe128b130bDecoder : public Filter
 public:
 	PCIe128b130bDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/PCIeDataLinkDecoder.cpp
+++ b/scopeprotocols/PCIeDataLinkDecoder.cpp
@@ -678,33 +678,33 @@ Gdk::Color PCIeDataLinkDecoder::GetColor(size_t i, size_t /*stream*/)
 		{
 			case PCIeDataLinkSymbol::TYPE_DLLP_TYPE:
 			case PCIeDataLinkSymbol::TYPE_DLLP_VC:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case PCIeDataLinkSymbol::TYPE_DLLP_DATA:
 			case PCIeDataLinkSymbol::TYPE_TLP_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case PCIeDataLinkSymbol::TYPE_DLLP_HEADER_CREDITS:
 			case PCIeDataLinkSymbol::TYPE_DLLP_DATA_CREDITS:
 			case PCIeDataLinkSymbol::TYPE_DLLP_SEQUENCE:
 			case PCIeDataLinkSymbol::TYPE_TLP_SEQUENCE:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case PCIeDataLinkSymbol::TYPE_DLLP_CRC_OK:
 			case PCIeDataLinkSymbol::TYPE_TLP_CRC_OK:
-				return m_standardColors[COLOR_CHECKSUM_OK];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 			case PCIeDataLinkSymbol::TYPE_DLLP_CRC_BAD:
 			case PCIeDataLinkSymbol::TYPE_TLP_CRC_BAD:
-				return m_standardColors[COLOR_CHECKSUM_BAD];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
 
 			case PCIeDataLinkSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string PCIeDataLinkDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/PCIeDataLinkDecoder.h
+++ b/scopeprotocols/PCIeDataLinkDecoder.h
@@ -102,7 +102,13 @@ public:
 	}
 };
 
-typedef Waveform<PCIeDataLinkSymbol> PCIeDataLinkWaveform;
+class PCIeDataLinkWaveform : public Waveform<PCIeDataLinkSymbol>
+{
+public:
+	PCIeDataLinkWaveform () : Waveform<PCIeDataLinkSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 /**
 	@brief Decoder for PCIe data link layer

--- a/scopeprotocols/PCIeDataLinkDecoder.h
+++ b/scopeprotocols/PCIeDataLinkDecoder.h
@@ -113,8 +113,8 @@ public:
 	PCIeDataLinkDecoder(const std::string& color);
 	virtual ~PCIeDataLinkDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/PCIeDataLinkDecoder.h
+++ b/scopeprotocols/PCIeDataLinkDecoder.h
@@ -113,9 +113,6 @@ public:
 	PCIeDataLinkDecoder(const std::string& color);
 	virtual ~PCIeDataLinkDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/PCIeGen2LogicalDecoder.cpp
+++ b/scopeprotocols/PCIeGen2LogicalDecoder.cpp
@@ -338,82 +338,71 @@ uint8_t PCIeGen2LogicalDecoder::RunScrambler(uint16_t& state)
 	return ret;
 }
 
-Gdk::Color PCIeGen2LogicalDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color PCIeLogicalWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<PCIeLogicalWaveform*>(GetData(0));
-	if(capture != NULL)
+	const PCIeLogicalSymbol& s = m_samples[i];
+
+	switch(s.m_type)
 	{
-		const PCIeLogicalSymbol& s = capture->m_samples[i];
+		case PCIeLogicalSymbol::TYPE_NO_SCRAMBLER:
+		case PCIeLogicalSymbol::TYPE_LOGICAL_IDLE:
+		case PCIeLogicalSymbol::TYPE_SKIP:
+			return StandardColors::colors[StandardColors::COLOR_IDLE];
 
-		switch(s.m_type)
-		{
-			case PCIeLogicalSymbol::TYPE_NO_SCRAMBLER:
-			case PCIeLogicalSymbol::TYPE_LOGICAL_IDLE:
-			case PCIeLogicalSymbol::TYPE_SKIP:
-				return StandardColors::colors[StandardColors::COLOR_IDLE];
+		case PCIeLogicalSymbol::TYPE_START_TLP:
+		case PCIeLogicalSymbol::TYPE_START_DLLP:
+		case PCIeLogicalSymbol::TYPE_END:
+		case PCIeLogicalSymbol::TYPE_END_DATA_STREAM:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case PCIeLogicalSymbol::TYPE_START_TLP:
-			case PCIeLogicalSymbol::TYPE_START_DLLP:
-			case PCIeLogicalSymbol::TYPE_END:
-			case PCIeLogicalSymbol::TYPE_END_DATA_STREAM:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+		case PCIeLogicalSymbol::TYPE_PAYLOAD_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-			case PCIeLogicalSymbol::TYPE_PAYLOAD_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
-
-			case PCIeLogicalSymbol::TYPE_END_BAD:
-			case PCIeLogicalSymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case PCIeLogicalSymbol::TYPE_END_BAD:
+		case PCIeLogicalSymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string PCIeGen2LogicalDecoder::GetText(size_t i, size_t /*stream*/)
+string PCIeLogicalWaveform::GetText(size_t i)
 {
 	char tmp[16];
 
-	auto capture = dynamic_cast<PCIeLogicalWaveform*>(GetData(0));
-	if(capture != NULL)
+	const PCIeLogicalSymbol& s = m_samples[i];
+
+	switch(s.m_type)
 	{
-		const PCIeLogicalSymbol& s = capture->m_samples[i];
+		case PCIeLogicalSymbol::TYPE_NO_SCRAMBLER:
+			return "Scrambler desynced";
 
-		switch(s.m_type)
-		{
-			case PCIeLogicalSymbol::TYPE_NO_SCRAMBLER:
-				return "Scrambler desynced";
+		case PCIeLogicalSymbol::TYPE_LOGICAL_IDLE:
+			return "Logical Idle";
 
-			case PCIeLogicalSymbol::TYPE_LOGICAL_IDLE:
-				return "Logical Idle";
+		case PCIeLogicalSymbol::TYPE_SKIP:
+			return "Skip";
 
-			case PCIeLogicalSymbol::TYPE_SKIP:
-				return "Skip";
+		case PCIeLogicalSymbol::TYPE_START_TLP:
+			return "TLP";
 
-			case PCIeLogicalSymbol::TYPE_START_TLP:
-				return "TLP";
+		case PCIeLogicalSymbol::TYPE_START_DLLP:
+			return "DLLP";
 
-			case PCIeLogicalSymbol::TYPE_START_DLLP:
-				return "DLLP";
+		case PCIeLogicalSymbol::TYPE_END:
+			return "End";
 
-			case PCIeLogicalSymbol::TYPE_END:
-				return "End";
+		case PCIeLogicalSymbol::TYPE_PAYLOAD_DATA:
+			snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			return tmp;
 
-			case PCIeLogicalSymbol::TYPE_PAYLOAD_DATA:
-				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				return tmp;
+		case PCIeLogicalSymbol::TYPE_END_BAD:
+			return "End Bad";
 
-			case PCIeLogicalSymbol::TYPE_END_BAD:
-				return "End Bad";
+		case PCIeLogicalSymbol::TYPE_END_DATA_STREAM:
+			return "End Data Stream";
 
-			case PCIeLogicalSymbol::TYPE_END_DATA_STREAM:
-				return "End Data Stream";
-
-			case PCIeLogicalSymbol::TYPE_ERROR:
-			default:
-				return "ERROR";
-		}
+		case PCIeLogicalSymbol::TYPE_ERROR:
+		default:
+			return "ERROR";
 	}
-	return "";
 }

--- a/scopeprotocols/PCIeGen2LogicalDecoder.cpp
+++ b/scopeprotocols/PCIeGen2LogicalDecoder.cpp
@@ -350,25 +350,25 @@ Gdk::Color PCIeGen2LogicalDecoder::GetColor(size_t i, size_t /*stream*/)
 			case PCIeLogicalSymbol::TYPE_NO_SCRAMBLER:
 			case PCIeLogicalSymbol::TYPE_LOGICAL_IDLE:
 			case PCIeLogicalSymbol::TYPE_SKIP:
-				return m_standardColors[COLOR_IDLE];
+				return StandardColors::colors[StandardColors::COLOR_IDLE];
 
 			case PCIeLogicalSymbol::TYPE_START_TLP:
 			case PCIeLogicalSymbol::TYPE_START_DLLP:
 			case PCIeLogicalSymbol::TYPE_END:
 			case PCIeLogicalSymbol::TYPE_END_DATA_STREAM:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case PCIeLogicalSymbol::TYPE_PAYLOAD_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case PCIeLogicalSymbol::TYPE_END_BAD:
 			case PCIeLogicalSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string PCIeGen2LogicalDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/PCIeGen2LogicalDecoder.h
+++ b/scopeprotocols/PCIeGen2LogicalDecoder.h
@@ -82,8 +82,8 @@ public:
 	PCIeGen2LogicalDecoder(const std::string& color);
 	virtual ~PCIeGen2LogicalDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/PCIeGen2LogicalDecoder.h
+++ b/scopeprotocols/PCIeGen2LogicalDecoder.h
@@ -71,7 +71,13 @@ public:
 	}
 };
 
-typedef Waveform<PCIeLogicalSymbol> PCIeLogicalWaveform;
+class PCIeLogicalWaveform : public Waveform<PCIeLogicalSymbol>
+{
+public:
+	PCIeLogicalWaveform () : Waveform<PCIeLogicalSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 /**
 	@brief Decoder for PCIe gen 1/2 logical sub-block

--- a/scopeprotocols/PCIeGen2LogicalDecoder.h
+++ b/scopeprotocols/PCIeGen2LogicalDecoder.h
@@ -82,9 +82,6 @@ public:
 	PCIeGen2LogicalDecoder(const std::string& color);
 	virtual ~PCIeGen2LogicalDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/PCIeTransportDecoder.cpp
+++ b/scopeprotocols/PCIeTransportDecoder.cpp
@@ -924,30 +924,30 @@ Gdk::Color PCIeTransportDecoder::GetColor(size_t i, size_t /*stream*/)
 			case PCIeTransportSymbol::TYPE_FIRST_BYTE_ENABLE:
 			case PCIeTransportSymbol::TYPE_LAST_BYTE_ENABLE:
 			case PCIeTransportSymbol::TYPE_COMPLETION_STATUS:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case PCIeTransportSymbol::TYPE_FLAGS:
 				if(s.m_data & PCIeTransportSymbol::FLAG_POISONED)
-					return m_standardColors[COLOR_ERROR];
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
 				else
-					return m_standardColors[COLOR_CONTROL];
+					return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case PCIeTransportSymbol::TYPE_REQUESTER_ID:
 			case PCIeTransportSymbol::TYPE_COMPLETER_ID:
 			case PCIeTransportSymbol::TYPE_ADDRESS_X32:
 			case PCIeTransportSymbol::TYPE_ADDRESS_X64:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case PCIeTransportSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case PCIeTransportSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string PCIeTransportDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/PCIeTransportDecoder.h
+++ b/scopeprotocols/PCIeTransportDecoder.h
@@ -121,8 +121,8 @@ public:
 	PCIeTransportDecoder(const std::string& color);
 	virtual ~PCIeTransportDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/PCIeTransportDecoder.h
+++ b/scopeprotocols/PCIeTransportDecoder.h
@@ -121,9 +121,6 @@ public:
 	PCIeTransportDecoder(const std::string& color);
 	virtual ~PCIeTransportDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/PCIeTransportDecoder.h
+++ b/scopeprotocols/PCIeTransportDecoder.h
@@ -110,7 +110,13 @@ public:
 	}
 };
 
-typedef Waveform<PCIeTransportSymbol> PCIeTransportWaveform;
+class PCIeTransportWaveform : public Waveform<PCIeTransportSymbol>
+{
+public:
+	PCIeTransportWaveform () : Waveform<PCIeTransportSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 /**
 	@brief Decoder for PCIe transport layer
@@ -131,8 +137,7 @@ public:
 
 	PROTOCOL_DECODER_INITPROC(PCIeTransportDecoder)
 
-protected:
-	std::string FormatID(uint16_t id);
+	static std::string FormatID(uint16_t id);
 };
 
 #endif

--- a/scopeprotocols/QSGMIIDecoder.cpp
+++ b/scopeprotocols/QSGMIIDecoder.cpp
@@ -55,10 +55,7 @@ QSGMIIDecoder::QSGMIIDecoder(const string& color)
 
 
 	m_displayformat = "Display Format";
-	m_parameters[m_displayformat] = FilterParameter(FilterParameter::TYPE_ENUM, Unit(Unit::UNIT_COUNTS));
-	m_parameters[m_displayformat].AddEnumValue("Dotted (K28.5 D21.5)", IBM8b10bDecoder::FORMAT_DOTTED);
-	m_parameters[m_displayformat].AddEnumValue("Hex (K.bc b5)", IBM8b10bDecoder::FORMAT_HEX);
-	m_parameters[m_displayformat].SetIntVal(IBM8b10bDecoder::FORMAT_DOTTED);
+	m_parameters[m_displayformat] = IBM8b10bDecoder::MakeIBM8b10bDisplayFormatParameter();
 }
 
 QSGMIIDecoder::~QSGMIIDecoder()

--- a/scopeprotocols/QSGMIIDecoder.cpp
+++ b/scopeprotocols/QSGMIIDecoder.cpp
@@ -161,15 +161,15 @@ Gdk::Color QSGMIIDecoder::GetColor(size_t i, size_t stream)
 		const IBM8b10bSymbol& s = capture->m_samples[i];
 
 		if(s.m_error)
-			return m_standardColors[COLOR_ERROR];
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 		else if(s.m_control)
-			return m_standardColors[COLOR_CONTROL];
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 		else
-			return m_standardColors[COLOR_DATA];
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 	}
 
 	//error
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 //TODO: this is pulled directly from the 8B10B decode, can we figure out how to refactor so this is cleaner?

--- a/scopeprotocols/QSGMIIDecoder.h
+++ b/scopeprotocols/QSGMIIDecoder.h
@@ -45,9 +45,6 @@ public:
 	QSGMIIDecoder(const std::string& color);
 	virtual ~QSGMIIDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/QSGMIIDecoder.h
+++ b/scopeprotocols/QSGMIIDecoder.h
@@ -45,8 +45,8 @@ public:
 	QSGMIIDecoder(const std::string& color);
 	virtual ~QSGMIIDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/QSGMIIDecoder.h
+++ b/scopeprotocols/QSGMIIDecoder.h
@@ -52,6 +52,9 @@ public:
 	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
 
 	PROTOCOL_DECODER_INITPROC(QSGMIIDecoder)
+
+protected:
+	std::string m_displayformat;
 };
 
 #endif

--- a/scopeprotocols/SDCmdDecoder.cpp
+++ b/scopeprotocols/SDCmdDecoder.cpp
@@ -384,27 +384,27 @@ Gdk::Color SDCmdDecoder::GetColor(size_t i, size_t /*stream*/)
 		switch(s.m_stype)
 		{
 			case SDCmdSymbol::TYPE_HEADER:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case SDCmdSymbol::TYPE_COMMAND:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case SDCmdSymbol::TYPE_COMMAND_ARGS:
 			case SDCmdSymbol::TYPE_RESPONSE_ARGS:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case SDCmdSymbol::TYPE_CRC_OK:
-				return m_standardColors[COLOR_CHECKSUM_OK];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 			case SDCmdSymbol::TYPE_CRC_BAD:
-				return m_standardColors[COLOR_CHECKSUM_BAD];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
 
 			case SDCmdSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string SDCmdDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/SDCmdDecoder.cpp
+++ b/scopeprotocols/SDCmdDecoder.cpp
@@ -96,7 +96,7 @@ void SDCmdDecoder::Refresh()
 	size_t len = dcmd.m_samples.size();
 
 	//Create the capture
-	auto cap = new SDCmdWaveform;
+	auto cap = new SDCmdWaveform(m_parameters[m_cardtypename]);
 	cap->m_timescale = 1;
 	cap->m_startTimestamp = clk->m_startTimestamp;
 	cap->m_startFemtoseconds = clk->m_startFemtoseconds;
@@ -213,7 +213,7 @@ void SDCmdDecoder::Refresh()
 
 					cap->m_samples.push_back(SDCmdSymbol(SDCmdSymbol::TYPE_COMMAND, data));
 
-					pack->m_headers["Command"] = GetText(cap->m_samples.size()-1, 0);
+					pack->m_headers["Command"] = cap->GetText(cap->m_samples.size()-1);
 
 					if(last_cmd >= 100)
 						pack->m_headers["Code"] = string("ACMD") + to_string(last_cmd - 100);
@@ -272,7 +272,7 @@ void SDCmdDecoder::Refresh()
 					tstart = end;
 					state = STATE_CRC;
 
-					pack->m_headers["Info"] = GetText(cap->m_samples.size()-1, 0);
+					pack->m_headers["Info"] = cap->GetText(cap->m_samples.size()-1);
 				}
 				break;
 
@@ -301,7 +301,7 @@ void SDCmdDecoder::Refresh()
 							cap->m_samples.push_back(SDCmdSymbol(SDCmdSymbol::TYPE_RESPONSE_ARGS,
 								extdata[0], extdata[1], extdata[2], extdata[3]));
 
-							pack->m_headers["Info"] = GetText(cap->m_samples.size()-1, 0);
+							pack->m_headers["Info"] = cap->GetText(cap->m_samples.size()-1);
 
 							//no CRC
 							//stop bit is parsed as last data bit
@@ -323,7 +323,7 @@ void SDCmdDecoder::Refresh()
 						tstart = end;
 						state = STATE_CRC;
 
-						pack->m_headers["Info"] = GetText(cap->m_samples.size()-1, 0);
+						pack->m_headers["Info"] = cap->GetText(cap->m_samples.size()-1);
 					}
 
 				}
@@ -375,917 +375,909 @@ bool SDCmdDecoder::GetShowDataColumn()
 	return false;
 }
 
-Gdk::Color SDCmdDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color SDCmdWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<SDCmdWaveform*>(GetData(0));
-	if(capture != NULL)
+	auto s = m_samples[i];
+	switch(s.m_stype)
 	{
-		auto s = capture->m_samples[i];
-		switch(s.m_stype)
-		{
-			case SDCmdSymbol::TYPE_HEADER:
-				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
+		case SDCmdSymbol::TYPE_HEADER:
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
-			case SDCmdSymbol::TYPE_COMMAND:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+		case SDCmdSymbol::TYPE_COMMAND:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case SDCmdSymbol::TYPE_COMMAND_ARGS:
-			case SDCmdSymbol::TYPE_RESPONSE_ARGS:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
+		case SDCmdSymbol::TYPE_COMMAND_ARGS:
+		case SDCmdSymbol::TYPE_RESPONSE_ARGS:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-			case SDCmdSymbol::TYPE_CRC_OK:
-				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
+		case SDCmdSymbol::TYPE_CRC_OK:
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
-			case SDCmdSymbol::TYPE_CRC_BAD:
-				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
+		case SDCmdSymbol::TYPE_CRC_BAD:
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
 
-			case SDCmdSymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case SDCmdSymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string SDCmdDecoder::GetText(size_t i, size_t /*stream*/)
+string SDCmdWaveform::GetText(size_t i)
 {
 	char tmp[128];
 
-	CardType cardtype = static_cast<CardType>(m_parameters[m_cardtypename].GetIntVal());
+	SDCmdDecoder::CardType cardtype = static_cast<SDCmdDecoder::CardType>(m_cardTypeParam.GetIntVal());
 
-	auto capture = dynamic_cast<SDCmdWaveform*>(GetData(0));
-	if(capture != NULL)
+	auto s = m_samples[i];
+	switch(s.m_stype)
 	{
-		auto s = capture->m_samples[i];
-		switch(s.m_stype)
-		{
-			case SDCmdSymbol::TYPE_HEADER:
-				if(s.m_data)
-					return "CMD";
+		case SDCmdSymbol::TYPE_HEADER:
+			if(s.m_data)
+				return "CMD";
+			else
+				return "REPLY";
+
+		case SDCmdSymbol::TYPE_COMMAND:
+			{
+				//We code ACMDs at offset 100
+				string ret;
+				if(s.m_data == 155)
+					ret = string("CMD55");
+				else if(s.m_data >= 100)
+					ret = string("ACMD") + to_string(s.m_data - 100);
 				else
-					return "REPLY";
+					ret = string("CMD") + to_string(s.m_data);
 
-			case SDCmdSymbol::TYPE_COMMAND:
+				switch(s.m_data)
 				{
-					//We code ACMDs at offset 100
-					string ret;
-					if(s.m_data == 155)
-						ret = string("CMD55");
-					else if(s.m_data >= 100)
-						ret = string("ACMD") + to_string(s.m_data - 100);
-					else
-						ret = string("CMD") + to_string(s.m_data);
+					case 0:		return "GO_IDLE_STATE";
 
-					switch(s.m_data)
-					{
-						case 0:		return "GO_IDLE_STATE";
-
-						//CMD1 reserved for SDIO
-						//eMMC uses it for SEND_OP_COND
-						case 1:
-							if(cardtype == SD_EMMC)
-								return "SEND_OP_COND";
-							else
-								return ret;
-
-						case 2:		return "ALL_SEND_CID";
-						case 3:		return "SEND_RELATIVE_ADDR";
-						case 4:		return "SET_DSR";
-
-						//CMD5 reserved for SDIO.
-						//eMMC uses it for SLEEP/AWAKE mode
-						case 5:
-							if(cardtype == SD_EMMC)
-								return "SLEEP_AWAKE";
-							break;
-
-						case 6:
-							if(cardtype == SD_EMMC)
-								return "SWITCH";
-							else
-								return "SET_BUS_WIDTH";
-
-						case 7:		return "SELECT_DESELECT_CARD";
-
-						case 8:
-							if(cardtype == SD_EMMC)
-								return "SEND_EXT_CSD";
-							else
-								return "SEND_IF_COND";
-
-						case 9:		return "SEND_CSD";
-						case 10:	return "SEND_CID";
-						case 11:	return "VOLTAGE_SWITCH";
-						case 12:	return "STOP_TRANSMISSION";
-						case 13:	return "SEND_STATUS";
-
-						//CMD14 reserved
-						//eMMC uses it for bus testing
-						case 14:
-							if(cardtype == SD_EMMC)
-								return "BUSTEST_R";
-							break;
-
-						case 15:	return "GO_INACTIVE_STATE";
-						case 16:	return "SET_BLOCKLEN";
-						case 17:	return "READ_SINGLE_BLOCK";
-						case 18:	return "READ_MULTIPLE_BLOCK";
-						case 19:	return "SEND_TUNING_BLOCK";
-						case 20:	return "SPEED_CLASS_CONTROL";
-
-						//CMD21 reserved
-						//eMMC uses it for link training in HS200 mode
-						case 21:
-							if(cardtype == SD_EMMC)
-								return "SEND_TUNING_BLOCK";
-							break;
-
-						case 22:	return "ADDRESS_EXTENSION";
-						case 23:	return "SET_BLOCK_COUNT";
-						case 24:	return "WRITE_BLOCK";
-						case 25:	return "WRITE_MULTIPLE_BLOCK";
-						//CMD26 reserved for manufacturer
-						case 27:	return "PROGRAM_CSD";
-						case 28:	return "SET_WRITE_PROT";
-						case 29:	return "CLR_WRITE_PROT";
-						case 30:	return "SEND_WRITE_PROT";
-						//CMD31 reserved
-						case 32:	return "ERASE_WR_BLK_START";
-						case 33:	return "ERASE_WR_BLK_END";
-						//CMD34-38 TODO
-						case 38:	return "ERASE";
-						//CMD39 reserved
-						//CMD40 defined by "DPS Spec" whatever that is
-						//CMD41 reserved
-						case 42:	return "LOCK_UNLOCK";
-
-						//CMD52-54 reserved for SDIO mode
-
-						case 55:
-						case 155:	//What is the "RCA"?
-							return "APP_CMD";
-
-						case 56:	return "GEN_CMD";
-						//CMD60-63 reserved for manufacturer
-
-						//Parse CMD63 response depending on what the previous command was
-						case 63:
-						{
-							//Should be a command at i-4
-							if(i < 4)
-								return "ERROR";
-							return GetText(i-4, 0);
-						}
-
-						//ACMD1-5 reserved
-						case 106:	return "SET_BUS_WIDTH";
-						//ACMD7-12 reserved
-						case 113:	return "SD_STATUS";
-						//ACMD14-16 reserved for DPS Specification
-						//ACMD17 reserved
-						//ACMD18 reserved for SD Security
-						//ACMD19-21 reserved
-						case 122:	return "SEND_NUM_WR_BLOCKS";
-						case 123:	return "SET_WR_BLK_ERASE_COUNT";
-						//ACMD24 reserved
-						//ACMD25-26 reserved for SD Security
-						//ACMD27 "shall not use"
-						//ACMD28 reserved for DPS Specification
-						//ACMD29 reserved
-						//ACMD30-35 reserved for Security Specification
-						//ACMD36-37 reserved
-						//ACMD38 reserved for SD Security
-						//ACMD39-40 reserved
-						case 141:	return "SEND_OP_COND";
-						case 142:	return "SET_CLR_CARD_DETECT";
-						//ACMD43-49 reserved for SD Security
-						//ACMD50?
-						case 151:	return "SEND_SCR";
-						//ACMD52-54 reserved for SD Security
-						//ACMD55 is just CMD55
-						//ACMD56-59 reserved for SD Security
-
-						default:
+					//CMD1 reserved for SDIO
+					//eMMC uses it for SEND_OP_COND
+					case 1:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+							return "SEND_OP_COND";
+						else
 							return ret;
-					}
-				}
-				break;
 
-			case SDCmdSymbol::TYPE_COMMAND_ARGS:
-				{
-					//Look up the command
-					//(TYPE_COMMAND_ARGS can never be the first sample in a waveform)
-					auto type = capture->m_samples[i-1].m_data;
+					case 2:		return "ALL_SEND_CID";
+					case 3:		return "SEND_RELATIVE_ADDR";
+					case 4:		return "SET_DSR";
 
-					snprintf(tmp, sizeof(tmp), "%08x", s.m_data);
-					string ret = tmp;
+					//CMD5 reserved for SDIO.
+					//eMMC uses it for SLEEP/AWAKE mode
+					case 5:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+							return "SLEEP_AWAKE";
+						break;
 
-					switch(type)
+					case 6:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+							return "SWITCH";
+						else
+							return "SET_BUS_WIDTH";
+
+					case 7:		return "SELECT_DESELECT_CARD";
+
+					case 8:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+							return "SEND_EXT_CSD";
+						else
+							return "SEND_IF_COND";
+
+					case 9:		return "SEND_CSD";
+					case 10:	return "SEND_CID";
+					case 11:	return "VOLTAGE_SWITCH";
+					case 12:	return "STOP_TRANSMISSION";
+					case 13:	return "SEND_STATUS";
+
+					//CMD14 reserved
+					//eMMC uses it for bus testing
+					case 14:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+							return "BUSTEST_R";
+						break;
+
+					case 15:	return "GO_INACTIVE_STATE";
+					case 16:	return "SET_BLOCKLEN";
+					case 17:	return "READ_SINGLE_BLOCK";
+					case 18:	return "READ_MULTIPLE_BLOCK";
+					case 19:	return "SEND_TUNING_BLOCK";
+					case 20:	return "SPEED_CLASS_CONTROL";
+
+					//CMD21 reserved
+					//eMMC uses it for link training in HS200 mode
+					case 21:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+							return "SEND_TUNING_BLOCK";
+						break;
+
+					case 22:	return "ADDRESS_EXTENSION";
+					case 23:	return "SET_BLOCK_COUNT";
+					case 24:	return "WRITE_BLOCK";
+					case 25:	return "WRITE_MULTIPLE_BLOCK";
+					//CMD26 reserved for manufacturer
+					case 27:	return "PROGRAM_CSD";
+					case 28:	return "SET_WRITE_PROT";
+					case 29:	return "CLR_WRITE_PROT";
+					case 30:	return "SEND_WRITE_PROT";
+					//CMD31 reserved
+					case 32:	return "ERASE_WR_BLK_START";
+					case 33:	return "ERASE_WR_BLK_END";
+					//CMD34-38 TODO
+					case 38:	return "ERASE";
+					//CMD39 reserved
+					//CMD40 defined by "DPS Spec" whatever that is
+					//CMD41 reserved
+					case 42:	return "LOCK_UNLOCK";
+
+					//CMD52-54 reserved for SDIO mode
+
+					case 55:
+					case 155:	//What is the "RCA"?
+						return "APP_CMD";
+
+					case 56:	return "GEN_CMD";
+					//CMD60-63 reserved for manufacturer
+
+					//Parse CMD63 response depending on what the previous command was
+					case 63:
 					{
-						//No arguments
-						case 0:
-						case 1:
-						case 2:
-							return "";
+						//Should be a command at i-4
+						if(i < 4)
+							return "ERROR";
+						return GetText(i-4);
+					}
 
-						//CMD5 SLEEP/AWAKE
-						case 5:
-							if(cardtype == SD_EMMC)
+					//ACMD1-5 reserved
+					case 106:	return "SET_BUS_WIDTH";
+					//ACMD7-12 reserved
+					case 113:	return "SD_STATUS";
+					//ACMD14-16 reserved for DPS Specification
+					//ACMD17 reserved
+					//ACMD18 reserved for SD Security
+					//ACMD19-21 reserved
+					case 122:	return "SEND_NUM_WR_BLOCKS";
+					case 123:	return "SET_WR_BLK_ERASE_COUNT";
+					//ACMD24 reserved
+					//ACMD25-26 reserved for SD Security
+					//ACMD27 "shall not use"
+					//ACMD28 reserved for DPS Specification
+					//ACMD29 reserved
+					//ACMD30-35 reserved for Security Specification
+					//ACMD36-37 reserved
+					//ACMD38 reserved for SD Security
+					//ACMD39-40 reserved
+					case 141:	return "SEND_OP_COND";
+					case 142:	return "SET_CLR_CARD_DETECT";
+					//ACMD43-49 reserved for SD Security
+					//ACMD50?
+					case 151:	return "SEND_SCR";
+					//ACMD52-54 reserved for SD Security
+					//ACMD55 is just CMD55
+					//ACMD56-59 reserved for SD Security
+
+					default:
+						return ret;
+				}
+			}
+			break;
+
+		case SDCmdSymbol::TYPE_COMMAND_ARGS:
+			{
+				//Look up the command
+				//(TYPE_COMMAND_ARGS can never be the first sample in a waveform)
+				auto type = m_samples[i-1].m_data;
+
+				snprintf(tmp, sizeof(tmp), "%08x", s.m_data);
+				string ret = tmp;
+
+				switch(type)
+				{
+					//No arguments
+					case 0:
+					case 1:
+					case 2:
+						return "";
+
+					//CMD5 SLEEP/AWAKE
+					case 5:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+						{
+							if(s.m_data & 0x8000)
+								snprintf(tmp, sizeof(tmp), "RCA=%04x SLEEP", s.m_data >> 16);
+							else
+								snprintf(tmp, sizeof(tmp), "RCA=%04x WAKE", s.m_data >> 16);
+							ret = tmp;
+						}
+						break;
+
+					//CMD6 SWITCH
+					case 6:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+						{
+							int access = (s.m_data && 24) & 3;
+							int cmdset = s.m_data & 3;
+							int index = (s.m_data >> 16) & 0xff;
+							int value = (s.m_data >> 8) & 0xff;
+
+							//EXT_CSD registers (emmc spec section 7.4)
+							//TODO: binary vs linear search
+							const char* regname = NULL;
+							static const struct
 							{
-								if(s.m_data & 0x8000)
-									snprintf(tmp, sizeof(tmp), "RCA=%04x SLEEP", s.m_data >> 16);
-								else
-									snprintf(tmp, sizeof(tmp), "RCA=%04x WAKE", s.m_data >> 16);
-								ret = tmp;
-							}
-							break;
-
-						//CMD6 SWITCH
-						case 6:
-							if(cardtype == SD_EMMC)
+								int index;
+								const char* name;
+							} extregs[] =
 							{
-								int access = (s.m_data && 24) & 3;
-								int cmdset = s.m_data & 3;
-								int index = (s.m_data >> 16) & 0xff;
-								int value = (s.m_data >> 8) & 0xff;
-
-								//EXT_CSD registers (emmc spec section 7.4)
-								//TODO: binary vs linear search
-								const char* regname = NULL;
-								static const struct
+								{15, "CMDQ_MODE_EN"},
+								{16, "SECURE_REMOVAL_TYPE"},
+								{17, "PRODUCT_STATE_AWARENESS_ENABLEMENT"},
+								//18-21 MAX_PRE_LOADING_DATA_SIZE
+								//22-25 PRE_LOADING_DATA_SIZE
+								{26, "FFU_STATUS"},
+								{29, "MODE_OPERATION_CODES"},
+								{30, "MODE_CONIG"},
+								{31, "BARRIER_CTRL"},
+								{32, "FLUSH_CACHE"},
+								{33, "CACHE_CTRL"},
+								{34, "POWER_OFF_NOTIFICATION"},
+								{35, "PACKED_FAILURE_INDEX"},
+								{36, "PACKED_COMMAND_STATUS"},
+								//37-51 CONTEXT_CONF
+								{52, "EXT_PARTITIONS_ATTRIBUTE_0"},
+								{53, "EXT_PARTITIONS_ATTRIBUTE_1"},
+								{54, "EXCEPTION_EVENTS_STATUS_0"},
+								{55, "EXCEPTION_EVENTS_STATUS_1"},
+								{56, "EXCEPTION_EVENTS_CTRL_0"},
+								{57, "EXCEPTION_EVENTS_CTRL_1"},
+								{58, "DYNCAP_NEEDED"},
+								{59, "CLASS_6_CTRL"},
+								{60, "INI_TIMEOUT_EMU"},
+								{61, "DATA_SECTOR_SIZE"},
+								{62, "USE_NATIVE_SECTOR"},
+								{63, "NATIVE_SECTOR_SIZE"},
+								//64-127 vendor specific
+								{130, "PROGRAM_CID_CSD_DDR_SUPPORT"},
+								{131, "PERIODIC_WAKEUP"},
+								{132, "TCASE_SUPPORT"},
+								{133, "PRODUCTION_STATE_AWARENESS"},
+								{134, "SEC_BAD_BLK_MGMNT"},
+								{136, "ENH_START_ADDR_0"},
+								{137, "ENH_START_ADDR_1"},
+								{138, "ENH_START_ADDR_2"},
+								{139, "ENH_START_ADDR_3"},
+								//140-142 ENH_SIZE_MULT
+								//143-154 GP_SIZE_MULT_GP0-3
+								{155, "PARTITION_SETTING_COMPLETED"},
+								{156, "PARTITIONS_ATTRIBUTE"},
+								//157-159 MAX_ENH_SIZE_MULT
+								{160, "PARTITIONING_SUPPORT"},
+								{161, "HPI_MGMT"},
+								{162, "RST_N_FUNCTION"},
+								{163, "BKOPS_EN"},
+								{164, "BKOPS_START"},
+								{165, "SANITIZE_START"},
+								{166, "WR_REL_PARAM"},
+								{167, "WR_REL_SET"},
+								{168, "RPMB_SIZE_MULT"},
+								{169, "FW_CONFIG"},
+								{171, "USER_WP"},
+								{173, "BOOT_WP"},
+								{174, "BOOT_WP_STATUS"},
+								{175, "ERASE_GROUP_DEV"},
+								{177, "BOOT_BUS_CONDITIONS"},
+								{178, "BOOT_CONFIG_PROT"},
+								{179, "PARTITION_CONFIG"},
+								{181, "ERASED_MEM_CONT"},
+								{183, "BUS_WIDTH"},
+								{184, "STROBE_SUPPORT"},
+								{185, "HS_TIMING"},
+								{187, "POWER_CLASS"},
+								{189, "CMD_SET_REV"},
+								{191, "CMD_SET"},
+								{192, "EXT_CSD_REV"},
+								{194, "CSD_STRUCTURE"},
+								{196, "DEVICE_TYPE"},
+								{197, "DRIVER_STRENGTH"},
+								{198, "OUT_OF_INTERRUPT_TIME"},
+								{199, "PARTITION_SWITCH_TIME"},
+								//200-203 PWR_CL_ff_vvv
+								//205-210 MIN_PERF_a_b_ff
+								{211, "SEC_WP_SUPPORT"},
+								//212-215 SEC_COUNT
+								{216, "SLEEP_NOTIFICATION_TIME"},
+								{217, "S_A_TIMEOUT"},
+								{218, "PRODUCTION_STATE_AWARENESS_TIMEOUT"},
+								{219, "S_C_VCCQ"},
+								{220, "S_C_VCC"},
+								{221, "HC_WP_GRP_SIZE"},
+								{222, "REL_WR_SEC_C"},
+								{223, "ERASE_TIMEOUT_MULT"},
+								{224, "HC_ERASE_GRP_SIZE"},
+								{225, "ACC_SIZE"},
+								{226, "BOOT_SIZE_MULT"},
+								//227 reserved
+								{228, "BOOT_INFO"},
+								{229, "SEC_TRIM_MULT"},
+								{230, "SEC_ERASE_MULT"},
+								{231, "SEC_FEATURE_SUPPORT"},
+								{232, "TRIM_MULT"},
+								//234-235 MIN_PERF_DDR_a_b_ff
+								//236-237 PWR_CL_ff_vvv
+								//238-239 PWR_CL_DDR_ff_vvv
+								{240, "CACHE_FLUSH_POLICY"},
+								{241, "INI_TIMEOUT_AP"},
+								//242-245 CORRECTLY_PRG_SECTORS_NUM
+								{246, "BKOPS_STATUS"},
+								{247, "POWER_OFF_LONG_TIME"},
+								{248, "GENERIC_CMD6_TIME"},
+								//249-252 CACHE_SIZE
+								//253 PWR_CL_DDR_ff_vvv
+								//254-261 FIRMWARE_VERSION
+								//262-263 DEVICE_VERSION
+								{264, "OPTIMAL_TRIM_UNIT_SIZE"},
+								{265, "OPTIMAL_WRITE_SIZE"},
+								{266, "OPTIMAL_READ_SIZE"},
+								{267, "PRE_EOL_INFO"},
+								{268, "DEVICE_LIFE_TIME_EST_TYPE_A"},
+								{269, "DEVICE_LIFE_TIME_EST_TYPE_B"},
+								//270-301 VENDOR_PROPRIETARY_HEALTH_REPORT
+								//302-305 NUMBER_OF_FW_SECTORS_CORRECTLY_PROGRAMMED
+								{307, "CMDQ_DEPTH"},
+								{308, "CMDQ_SUPPORT"},
+								//309-485 reserved
+								{486, "BARRIER_SUPPORT"},
+								//487-490 FFU_ARG
+								{491, "OPERATION_CODES_TIMEOUT"},
+								{492, "FFU_FEATURES"},
+								{493, "SUPPORTED_MODES"},
+								{494, "EXT_SUPPORT"},
+								{495, "LARGE_UNIT_SIZE_M1"},
+								{496, "CONTEXT_CAPABILITIES"},
+								{497, "TAG_RES_SIZE"},
+								{498, "TAG_UNIT_SIZE"},
+								{499, "DATA_TAG_SUPPORT"},
+								{500, "MAX_PACKED_WRITES"},
+								{501, "MAX_PACKED_READS"},
+								{502, "BKOPS_SUPPORT"},
+								{503, "HPI_FEATURES"},
+								{504, "S_CMD_SET"},
+								{505, "EXT_SECURITY_ERR"}
+							};
+							for(size_t j=0; j<sizeof(extregs)/sizeof(extregs[0]); j++)
+							{
+								if(extregs[j].index == index)
 								{
-									int index;
-									const char* name;
-								} extregs[] =
-								{
-									{15, "CMDQ_MODE_EN"},
-									{16, "SECURE_REMOVAL_TYPE"},
-									{17, "PRODUCT_STATE_AWARENESS_ENABLEMENT"},
-									//18-21 MAX_PRE_LOADING_DATA_SIZE
-									//22-25 PRE_LOADING_DATA_SIZE
-									{26, "FFU_STATUS"},
-									{29, "MODE_OPERATION_CODES"},
-									{30, "MODE_CONIG"},
-									{31, "BARRIER_CTRL"},
-									{32, "FLUSH_CACHE"},
-									{33, "CACHE_CTRL"},
-									{34, "POWER_OFF_NOTIFICATION"},
-									{35, "PACKED_FAILURE_INDEX"},
-									{36, "PACKED_COMMAND_STATUS"},
-									//37-51 CONTEXT_CONF
-									{52, "EXT_PARTITIONS_ATTRIBUTE_0"},
-									{53, "EXT_PARTITIONS_ATTRIBUTE_1"},
-									{54, "EXCEPTION_EVENTS_STATUS_0"},
-									{55, "EXCEPTION_EVENTS_STATUS_1"},
-									{56, "EXCEPTION_EVENTS_CTRL_0"},
-									{57, "EXCEPTION_EVENTS_CTRL_1"},
-									{58, "DYNCAP_NEEDED"},
-									{59, "CLASS_6_CTRL"},
-									{60, "INI_TIMEOUT_EMU"},
-									{61, "DATA_SECTOR_SIZE"},
-									{62, "USE_NATIVE_SECTOR"},
-									{63, "NATIVE_SECTOR_SIZE"},
-									//64-127 vendor specific
-									{130, "PROGRAM_CID_CSD_DDR_SUPPORT"},
-									{131, "PERIODIC_WAKEUP"},
-									{132, "TCASE_SUPPORT"},
-									{133, "PRODUCTION_STATE_AWARENESS"},
-									{134, "SEC_BAD_BLK_MGMNT"},
-									{136, "ENH_START_ADDR_0"},
-									{137, "ENH_START_ADDR_1"},
-									{138, "ENH_START_ADDR_2"},
-									{139, "ENH_START_ADDR_3"},
-									//140-142 ENH_SIZE_MULT
-									//143-154 GP_SIZE_MULT_GP0-3
-									{155, "PARTITION_SETTING_COMPLETED"},
-									{156, "PARTITIONS_ATTRIBUTE"},
-									//157-159 MAX_ENH_SIZE_MULT
-									{160, "PARTITIONING_SUPPORT"},
-									{161, "HPI_MGMT"},
-									{162, "RST_N_FUNCTION"},
-									{163, "BKOPS_EN"},
-									{164, "BKOPS_START"},
-									{165, "SANITIZE_START"},
-									{166, "WR_REL_PARAM"},
-									{167, "WR_REL_SET"},
-									{168, "RPMB_SIZE_MULT"},
-									{169, "FW_CONFIG"},
-									{171, "USER_WP"},
-									{173, "BOOT_WP"},
-									{174, "BOOT_WP_STATUS"},
-									{175, "ERASE_GROUP_DEV"},
-									{177, "BOOT_BUS_CONDITIONS"},
-									{178, "BOOT_CONFIG_PROT"},
-									{179, "PARTITION_CONFIG"},
-									{181, "ERASED_MEM_CONT"},
-									{183, "BUS_WIDTH"},
-									{184, "STROBE_SUPPORT"},
-									{185, "HS_TIMING"},
-									{187, "POWER_CLASS"},
-									{189, "CMD_SET_REV"},
-									{191, "CMD_SET"},
-									{192, "EXT_CSD_REV"},
-									{194, "CSD_STRUCTURE"},
-									{196, "DEVICE_TYPE"},
-									{197, "DRIVER_STRENGTH"},
-									{198, "OUT_OF_INTERRUPT_TIME"},
-									{199, "PARTITION_SWITCH_TIME"},
-									//200-203 PWR_CL_ff_vvv
-									//205-210 MIN_PERF_a_b_ff
-									{211, "SEC_WP_SUPPORT"},
-									//212-215 SEC_COUNT
-									{216, "SLEEP_NOTIFICATION_TIME"},
-									{217, "S_A_TIMEOUT"},
-									{218, "PRODUCTION_STATE_AWARENESS_TIMEOUT"},
-									{219, "S_C_VCCQ"},
-									{220, "S_C_VCC"},
-									{221, "HC_WP_GRP_SIZE"},
-									{222, "REL_WR_SEC_C"},
-									{223, "ERASE_TIMEOUT_MULT"},
-									{224, "HC_ERASE_GRP_SIZE"},
-									{225, "ACC_SIZE"},
-									{226, "BOOT_SIZE_MULT"},
-									//227 reserved
-									{228, "BOOT_INFO"},
-									{229, "SEC_TRIM_MULT"},
-									{230, "SEC_ERASE_MULT"},
-									{231, "SEC_FEATURE_SUPPORT"},
-									{232, "TRIM_MULT"},
-									//234-235 MIN_PERF_DDR_a_b_ff
-									//236-237 PWR_CL_ff_vvv
-									//238-239 PWR_CL_DDR_ff_vvv
-									{240, "CACHE_FLUSH_POLICY"},
-									{241, "INI_TIMEOUT_AP"},
-									//242-245 CORRECTLY_PRG_SECTORS_NUM
-									{246, "BKOPS_STATUS"},
-									{247, "POWER_OFF_LONG_TIME"},
-									{248, "GENERIC_CMD6_TIME"},
-									//249-252 CACHE_SIZE
-									//253 PWR_CL_DDR_ff_vvv
-									//254-261 FIRMWARE_VERSION
-									//262-263 DEVICE_VERSION
-									{264, "OPTIMAL_TRIM_UNIT_SIZE"},
-									{265, "OPTIMAL_WRITE_SIZE"},
-									{266, "OPTIMAL_READ_SIZE"},
-									{267, "PRE_EOL_INFO"},
-									{268, "DEVICE_LIFE_TIME_EST_TYPE_A"},
-									{269, "DEVICE_LIFE_TIME_EST_TYPE_B"},
-									//270-301 VENDOR_PROPRIETARY_HEALTH_REPORT
-									//302-305 NUMBER_OF_FW_SECTORS_CORRECTLY_PROGRAMMED
-									{307, "CMDQ_DEPTH"},
-									{308, "CMDQ_SUPPORT"},
-									//309-485 reserved
-									{486, "BARRIER_SUPPORT"},
-									//487-490 FFU_ARG
-									{491, "OPERATION_CODES_TIMEOUT"},
-									{492, "FFU_FEATURES"},
-									{493, "SUPPORTED_MODES"},
-									{494, "EXT_SUPPORT"},
-									{495, "LARGE_UNIT_SIZE_M1"},
-									{496, "CONTEXT_CAPABILITIES"},
-									{497, "TAG_RES_SIZE"},
-									{498, "TAG_UNIT_SIZE"},
-									{499, "DATA_TAG_SUPPORT"},
-									{500, "MAX_PACKED_WRITES"},
-									{501, "MAX_PACKED_READS"},
-									{502, "BKOPS_SUPPORT"},
-									{503, "HPI_FEATURES"},
-									{504, "S_CMD_SET"},
-									{505, "EXT_SECURITY_ERR"}
-								};
-								for(size_t j=0; j<sizeof(extregs)/sizeof(extregs[0]); j++)
-								{
-									if(extregs[j].index == index)
-									{
-										regname = extregs[j].name;
-										break;
-									}
+									regname = extregs[j].name;
+									break;
 								}
-
-								switch(access)
-								{
-									case 0:
-										snprintf(tmp, sizeof(tmp), "CommandSet %d", cmdset);
-										break;
-									case 1:
-										if(regname)
-											snprintf(tmp, sizeof(tmp), "%s |= 0x%02x", regname, value);
-										else
-											snprintf(tmp, sizeof(tmp), "EXT_CSD[%d] |= 0x%02x", index, value);
-										break;
-									case 2:
-										if(regname)
-											snprintf(tmp, sizeof(tmp), "%s &= ~0x%02x", regname, value);
-										else
-											snprintf(tmp, sizeof(tmp), "EXT_CSD[%d] &= ~0x%02x", index, value);
-										break;
-									case 3:
-										if(regname)
-											snprintf(tmp, sizeof(tmp), "%s = 0x%02x", regname, value);
-										else
-											snprintf(tmp, sizeof(tmp), "EXT_CSD[%d] = 0x%02x", index, value);
-										break;
-								}
-								ret = tmp;
 							}
-							//TODO SDIO decoding
-							break;
 
-						//CMD7 Select/Deselect Card
-						case 7:
+							switch(access)
+							{
+								case 0:
+									snprintf(tmp, sizeof(tmp), "CommandSet %d", cmdset);
+									break;
+								case 1:
+									if(regname)
+										snprintf(tmp, sizeof(tmp), "%s |= 0x%02x", regname, value);
+									else
+										snprintf(tmp, sizeof(tmp), "EXT_CSD[%d] |= 0x%02x", index, value);
+									break;
+								case 2:
+									if(regname)
+										snprintf(tmp, sizeof(tmp), "%s &= ~0x%02x", regname, value);
+									else
+										snprintf(tmp, sizeof(tmp), "EXT_CSD[%d] &= ~0x%02x", index, value);
+									break;
+								case 3:
+									if(regname)
+										snprintf(tmp, sizeof(tmp), "%s = 0x%02x", regname, value);
+									else
+										snprintf(tmp, sizeof(tmp), "EXT_CSD[%d] = 0x%02x", index, value);
+									break;
+							}
+							ret = tmp;
+						}
+						//TODO SDIO decoding
+						break;
+
+					//CMD7 Select/Deselect Card
+					case 7:
+						snprintf(tmp, sizeof(tmp), "RCA=%04x", s.m_data >> 16);
+						ret = tmp;
+						break;
+
+					//For eMMC: SEND_EXT_CSD (no arguments)
+					//For SD: CMD8 Send Interface Condition (4.3.13)
+					case 8:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+							ret = "";
+						else
+						{
+							snprintf(tmp, sizeof(tmp), "%02x", s.m_data & 0xff);
+							ret = string("Check ") + tmp;
+
+							if(s.m_data & 0x2000)
+								ret += " 1V2? ";
+							if(s.m_data & 0x1000)
+								ret += " PCIe? ";
+
+							int voltage = (s.m_data >> 8) & 0xf;
+							if(voltage == 1)
+								ret += " 3V3";
+							else
+								ret += " Vunknown";
+						}
+						break;
+
+					//CMD9 SEND_CSD
+					case 9:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+						{
 							snprintf(tmp, sizeof(tmp), "RCA=%04x", s.m_data >> 16);
 							ret = tmp;
-							break;
+						}
+						break;
 
-						//For eMMC: SEND_EXT_CSD (no arguments)
-						//For SD: CMD8 Send Interface Condition (4.3.13)
-						case 8:
-							if(cardtype == SD_EMMC)
-								ret = "";
+					//CMD16 Set Block Length
+					case 16:
+						snprintf(tmp, sizeof(tmp), "Block size = %d", s.m_data);
+						ret = tmp;
+						break;
+
+					//CMD17 Read Single Block
+					//CMD18 Read Multiple Block
+					//CMD24 Write Block
+					//CMD25 Write Multiple Block
+					case 17:
+					case 18:
+					case 24:
+					case 25:
+						snprintf(tmp, sizeof(tmp), "LBA = %08x", s.m_data);
+						ret = tmp;
+						break;
+
+					//ACMD6 SET_BUS_WIDTH
+					case 106:
+						if( (s.m_data & 3) == 0)
+							ret = "x1";
+						else if( (s.m_data & 3) == 2)
+							ret = "x4";
+						else
+							ret = "Invalid bus width";
+						break;
+
+					//ACMD41 SD_SEND_OP_COND
+					//30 HCS
+					//28 XPC
+					//24 S18R
+					//23:0 VDD range
+					case 141:
+						{
+							ret = "";
+							if(s.m_data & 0x40000000)
+								ret += "HCS ";
+							if(s.m_data & 0x10000000)
+								ret += "XPC ";
+
+							//VDD voltage window
+							uint32_t window = s.m_data & 0xffffff;
+							if(window == 0)
+								ret += "Voltage?";
 							else
 							{
-								snprintf(tmp, sizeof(tmp), "%02x", s.m_data & 0xff);
-								ret = string("Check ") + tmp;
+								float vmax = 0;
+								float vmin = 3.6;
 
-								if(s.m_data & 0x2000)
-									ret += " 1V2? ";
-								if(s.m_data & 0x1000)
-									ret += " PCIe? ";
-
-								int voltage = (s.m_data >> 8) & 0xf;
-								if(voltage == 1)
-									ret += " 3V3";
-								else
-									ret += " Vunknown";
-							}
-							break;
-
-						//CMD9 SEND_CSD
-						case 9:
-							if(cardtype == SD_EMMC)
-							{
-								snprintf(tmp, sizeof(tmp), "RCA=%04x", s.m_data >> 16);
-								ret = tmp;
-							}
-							break;
-
-						//CMD16 Set Block Length
-						case 16:
-							snprintf(tmp, sizeof(tmp), "Block size = %d", s.m_data);
-							ret = tmp;
-							break;
-
-						//CMD17 Read Single Block
-						//CMD18 Read Multiple Block
-						//CMD24 Write Block
-						//CMD25 Write Multiple Block
-						case 17:
-						case 18:
-						case 24:
-						case 25:
-							snprintf(tmp, sizeof(tmp), "LBA = %08x", s.m_data);
-							ret = tmp;
-							break;
-
-						//ACMD6 SET_BUS_WIDTH
-						case 106:
-							if( (s.m_data & 3) == 0)
-								ret = "x1";
-							else if( (s.m_data & 3) == 2)
-								ret = "x4";
-							else
-								ret = "Invalid bus width";
-							break;
-
-						//ACMD41 SD_SEND_OP_COND
-						//30 HCS
-						//28 XPC
-						//24 S18R
-						//23:0 VDD range
-						case 141:
-							{
-								ret = "";
-								if(s.m_data & 0x40000000)
-									ret += "HCS ";
-								if(s.m_data & 0x10000000)
-									ret += "XPC ";
-
-								//VDD voltage window
-								uint32_t window = s.m_data & 0xffffff;
-								if(window == 0)
-									ret += "Voltage?";
-								else
+								if(window & 0x00800000)
 								{
-									float vmax = 0;
-									float vmin = 3.6;
-
-									if(window & 0x00800000)
-									{
-										vmax = max(vmax, 3.6f);
-										vmin = min(vmin, 3.5f);
-									}
-									if(window & 0x00400000)
-									{
-										vmax = max(vmax, 3.5f);
-										vmin = min(vmin, 3.4f);
-									}
-									if(window & 0x00200000)
-									{
-										vmax = max(vmax, 3.4f);
-										vmin = min(vmin, 3.3f);
-									}
-									if(window & 0x00100000)
-									{
-										vmax = max(vmax, 3.3f);
-										vmin = min(vmin, 3.2f);
-									}
-									if(window & 0x00080000)
-									{
-										vmax = max(vmax, 3.2f);
-										vmin = min(vmin, 3.1f);
-									}
-									if(window & 0x00040000)
-									{
-										vmax = max(vmax, 3.1f);
-										vmin = min(vmin, 3.0f);
-									}
-									if(window & 0x00020000)
-									{
-										vmax = max(vmax, 3.0f);
-										vmin = min(vmin, 2.9f);
-									}
-									if(window & 0x00010000)
-									{
-										vmax = max(vmax, 2.9f);
-										vmin = min(vmin, 2.8f);
-									}
-									if(window & 0x00008000)
-									{
-										vmax = max(vmax, 2.8f);
-										vmin = min(vmin, 2.7f);
-									}
-
-									snprintf(tmp, sizeof(tmp), "Vdd = %.1f - %.1f", vmin, vmax);
-									ret += tmp;
+									vmax = max(vmax, 3.6f);
+									vmin = min(vmin, 3.5f);
 								}
+								if(window & 0x00400000)
+								{
+									vmax = max(vmax, 3.5f);
+									vmin = min(vmin, 3.4f);
+								}
+								if(window & 0x00200000)
+								{
+									vmax = max(vmax, 3.4f);
+									vmin = min(vmin, 3.3f);
+								}
+								if(window & 0x00100000)
+								{
+									vmax = max(vmax, 3.3f);
+									vmin = min(vmin, 3.2f);
+								}
+								if(window & 0x00080000)
+								{
+									vmax = max(vmax, 3.2f);
+									vmin = min(vmin, 3.1f);
+								}
+								if(window & 0x00040000)
+								{
+									vmax = max(vmax, 3.1f);
+									vmin = min(vmin, 3.0f);
+								}
+								if(window & 0x00020000)
+								{
+									vmax = max(vmax, 3.0f);
+									vmin = min(vmin, 2.9f);
+								}
+								if(window & 0x00010000)
+								{
+									vmax = max(vmax, 2.9f);
+									vmin = min(vmin, 2.8f);
+								}
+								if(window & 0x00008000)
+								{
+									vmax = max(vmax, 2.8f);
+									vmin = min(vmin, 2.7f);
+								}
+
+								snprintf(tmp, sizeof(tmp), "Vdd = %.1f - %.1f", vmin, vmax);
+								ret += tmp;
 							}
-							break;
+						}
+						break;
 
-						//ACMD42 SET_CLR_CARD_DETECT
-						case 142:
-							if(s.m_data & 1)
-								ret = "CD/DAT3 pullup enable";
-							else
-								ret = "CD/DAT3 pullup disable";
+					//ACMD42 SET_CLR_CARD_DETECT
+					case 142:
+						if(s.m_data & 1)
+							ret = "CD/DAT3 pullup enable";
+						else
+							ret = "CD/DAT3 pullup disable";
 
-						default:
-							break;
-					}
-
-					return ret;
+					default:
+						break;
 				}
 
-			case SDCmdSymbol::TYPE_RESPONSE_ARGS:
+				return ret;
+			}
+
+		case SDCmdSymbol::TYPE_RESPONSE_ARGS:
+			{
+				//Look up the command
+				//(TYPE_RESPONSE_ARGS can never be the first sample in a waveform)
+				auto type = m_samples[i-1].m_data;
+
+				//Back up by 5 (previous command) and figure out what we got
+				if(i >= 5)
 				{
-					//Look up the command
-					//(TYPE_RESPONSE_ARGS can never be the first sample in a waveform)
-					auto type = capture->m_samples[i-1].m_data;
-
-					//Back up by 5 (previous command) and figure out what we got
-					if(i >= 5)
-					{
-						type = capture->m_samples[i-5].m_data;
-					}
-
-					snprintf(tmp, sizeof(tmp), "%08x", s.m_data);
-					string ret = tmp;
-
-					switch(type)
-					{
-						//R3 (OCR register)
-						//(only valid for eMMC)
-						case 1:
-
-							//Card ready
-							if(s.m_data & 0x80000000)
-							{
-								int access = (s.m_data >> 29) & 3;
-								if(access == 0)
-									ret = "ByteAcc ";
-								else if(access == 2)
-									ret = "SectorAcc ";
-								else
-									ret = "InvalidAcc ";
-								if(s.m_data & 0x80)
-									ret += "1V8 ";
-							}
-
-							//Card busy, still initializing
-							else
-								ret = "BUSY";
-
-							break;
-
-						//4.9.3 R2 (CID or CSD register)
-						case 2:
-							{
-								snprintf(tmp, sizeof(tmp), "%08x %08x %08x %08x ",
-									s.m_data, s.m_extdata1, s.m_extdata2, s.m_extdata3);
-								ret = tmp;
-							}
-							break;
-
-						//4.9.5 R6 (Published RCA response)
-						case 3:
-							{
-								snprintf(tmp, sizeof(tmp), "RCA=%04x ", s.m_data >> 16);
-								ret = tmp;
-
-								//Low 16 bits have same meaning as 23, 22, 19, 12:0 from normal card status
-
-								if(s.m_data & 0x00008000)
-									ret += "COM_CRC_ERROR ";
-								if(s.m_data & 0x00004000)
-									ret += "ILLEGAL_COMMAND ";
-								if(s.m_data & 0x00002000)
-									ret += "ERROR ";
-								if(s.m_data & 0x00000100)
-									ret += "READY_FOR_DATA ";
-								if(s.m_data & 0x00000040)
-									ret += "FX_EVENT ";
-								if(s.m_data & 0x00000020)
-									ret += "APP_CMD ";
-								if(s.m_data & 0x00000010)
-									ret += "RESERVED_SDIO ";
-								if(s.m_data & 0x00000008)
-									ret += "AKE_SEQ_ERR ";
-								if(s.m_data & 0x00060084)
-									ret += "RESERVED ";
-
-								//12:9 CURRENT_STATE
-								uint32_t state = (s.m_data >> 9) & 0xf;
-								switch(state)
-								{
-									case 0:
-										ret += "idle";
-										break;
-
-									case 1:
-										ret += "ready";
-										break;
-
-									case 2:
-										ret += "ident";
-										break;
-
-									case 3:
-										ret += "stby";
-										break;
-
-									case 4:
-										ret += "tran";
-										break;
-
-									case 5:
-										ret += "data";
-										break;
-
-									case 6:
-										ret += "rcv";
-										break;
-
-									case 7:
-										ret += "prg";
-										break;
-
-									case 8:
-										ret += "dis";
-										break;
-
-									default:
-										ret += "reserved_state";
-								}
-							}
-							break;
-
-
-						//SD: R7 Card Interface Condition (4.9.6)
-						//eMMC: Extended CSD (reply is a block of data on the data pins)
-						case 8:
-							if(cardtype == SD_EMMC)
-								ret = "";
-							else
-							{
-								snprintf(tmp, sizeof(tmp), "%02x", s.m_data & 0xff);
-								ret = string("Check ") + tmp;
-
-								if(s.m_data & 0x2000)
-									ret += " 1V2 ";
-								if(s.m_data & 0x1000)
-									ret += " PCIe ";
-
-								int voltage = (s.m_data >> 8) & 0xf;
-								if(voltage == 1)
-									ret += " 3V3";
-								else
-									ret += " Vunknown";
-
-							}
-							break;
-
-						//R3 OCR Register (4.9.4, 5.1). Operation Conditions Register Register :)
-						case 141:
-							{
-								ret = "";
-								if( (s.m_data & 0x80000000) == 0)
-									ret += "BUSY ";
-
-								//CCS bit is only valid after powerup is complete
-								else
-								{
-									if(s.m_data & 0x08000000)
-										ret += "UC";
-									else if(s.m_data & 0x40000000)
-										ret += "HC/XC ";
-									else
-										ret += "SC ";
-								}
-
-								if(s.m_data & 0x01000000)
-									ret += "S18A ";
-
-								//VDD voltage window
-								uint32_t window = s.m_data & 0xffffff;
-								if(window == 0)
-									ret += "Voltage?";
-								else
-								{
-									float vmax = 0;
-									float vmin = 3.6;
-
-									if(window & 0x00800000)
-									{
-										vmax = max(vmax, 3.6f);
-										vmin = min(vmin, 3.5f);
-									}
-									if(window & 0x00400000)
-									{
-										vmax = max(vmax, 3.5f);
-										vmin = min(vmin, 3.4f);
-									}
-									if(window & 0x00200000)
-									{
-										vmax = max(vmax, 3.4f);
-										vmin = min(vmin, 3.3f);
-									}
-									if(window & 0x00100000)
-									{
-										vmax = max(vmax, 3.3f);
-										vmin = min(vmin, 3.2f);
-									}
-									if(window & 0x00080000)
-									{
-										vmax = max(vmax, 3.2f);
-										vmin = min(vmin, 3.1f);
-									}
-									if(window & 0x00040000)
-									{
-										vmax = max(vmax, 3.1f);
-										vmin = min(vmin, 3.0f);
-									}
-									if(window & 0x00020000)
-									{
-										vmax = max(vmax, 3.0f);
-										vmin = min(vmin, 2.9f);
-									}
-									if(window & 0x00010000)
-									{
-										vmax = max(vmax, 2.9f);
-										vmin = min(vmin, 2.8f);
-									}
-									if(window & 0x00008000)
-									{
-										vmax = max(vmax, 2.8f);
-										vmin = min(vmin, 2.7f);
-									}
-
-									snprintf(tmp, sizeof(tmp), "Vdd = %.1f - %.1f", vmin, vmax);
-									ret += tmp;
-								}
-							}
-							break;
-
-						//Parse anything else as R1 Card Status (4.10)
-						default:
-							{
-								ret = "";
-								if(s.m_data & 0x80000000)
-									ret += "OUT_OF_RANGE ";
-								if(s.m_data & 0x40000000)
-									ret += "ADDRESS_ERROR ";
-								if(s.m_data & 0x20000000)
-									ret += "BLOCK_LEN_ERROR ";
-								if(s.m_data & 0x10000000)
-									ret += "ERASE_SEQ_ERROR ";
-								if(s.m_data & 0x08000000)
-									ret += "ERASE_PARAM ";
-								if(s.m_data & 0x04000000)
-									ret += "WP_VIOLATION ";
-								if(s.m_data & 0x02000000)
-									ret += "CARD_IS_LOCKED ";
-								if(s.m_data & 0x01000000)
-									ret += "LOCK_UNLOCK_FAILED ";
-								if(s.m_data & 0x00800000)
-									ret += "COM_CRC_ERROR ";
-								if(s.m_data & 0x00400000)
-									ret += "ILLEGAL_COMMAND ";
-								if(s.m_data & 0x00200000)
-									ret += "CARD_ECC_FAILED ";
-								if(s.m_data & 0x00100000)
-									ret += "CC_ERROR ";
-								if(s.m_data & 0x00080000)
-									ret += "ERROR ";
-								if(s.m_data & 0x00010000)
-									ret += "CSD_OVERWRITE ";
-								if(s.m_data & 0x00008000)
-									ret += "WP_ERASE_SKIP ";
-								if(s.m_data & 0x00004000)
-									ret += "CARD_ECC_DISABLED ";
-								if(s.m_data & 0x00002000)
-									ret += "ERASE_RESET ";
-								if(s.m_data & 0x00000100)
-									ret += "READY_FOR_DATA ";
-								if(s.m_data & 0x00000040)
-									ret += "FX_EVENT ";
-								if(s.m_data & 0x00000020)
-									ret += "APP_CMD ";
-								if(s.m_data & 0x00000010)
-									ret += "RESERVED_SDIO ";
-								if(s.m_data & 0x00000008)
-									ret += "AKE_SEQ_ERR ";
-								if(s.m_data & 0x00060084)
-									ret += "RESERVED ";
-
-								//12:9 CURRENT_STATE
-								uint32_t state = (s.m_data >> 9) & 0xf;
-								switch(state)
-								{
-									case 0:
-										ret += "idle";
-										break;
-
-									case 1:
-										ret += "ready";
-										break;
-
-									case 2:
-										ret += "ident";
-										break;
-
-									case 3:
-										ret += "stby";
-										break;
-
-									case 4:
-										ret += "tran";
-										break;
-
-									case 5:
-										ret += "data";
-										break;
-
-									case 6:
-										ret += "rcv";
-										break;
-
-									case 7:
-										ret += "prg";
-										break;
-
-									case 8:
-										ret += "dis";
-										break;
-
-									default:
-										ret += "reserved_state";
-								}
-							}
-							break;
-					}
-
-					return ret;
+					type = m_samples[i-5].m_data;
 				}
 
-			case SDCmdSymbol::TYPE_CRC_OK:
-			case SDCmdSymbol::TYPE_CRC_BAD:
-				snprintf(tmp, sizeof(tmp), "CRC: %02x", s.m_data);
-				return string(tmp);
+				snprintf(tmp, sizeof(tmp), "%08x", s.m_data);
+				string ret = tmp;
 
-			case SDCmdSymbol::TYPE_ERROR:
-			default:
-				return "ERROR";
-		}
+				switch(type)
+				{
+					//R3 (OCR register)
+					//(only valid for eMMC)
+					case 1:
+
+						//Card ready
+						if(s.m_data & 0x80000000)
+						{
+							int access = (s.m_data >> 29) & 3;
+							if(access == 0)
+								ret = "ByteAcc ";
+							else if(access == 2)
+								ret = "SectorAcc ";
+							else
+								ret = "InvalidAcc ";
+							if(s.m_data & 0x80)
+								ret += "1V8 ";
+						}
+
+						//Card busy, still initializing
+						else
+							ret = "BUSY";
+
+						break;
+
+					//4.9.3 R2 (CID or CSD register)
+					case 2:
+						{
+							snprintf(tmp, sizeof(tmp), "%08x %08x %08x %08x ",
+								s.m_data, s.m_extdata1, s.m_extdata2, s.m_extdata3);
+							ret = tmp;
+						}
+						break;
+
+					//4.9.5 R6 (Published RCA response)
+					case 3:
+						{
+							snprintf(tmp, sizeof(tmp), "RCA=%04x ", s.m_data >> 16);
+							ret = tmp;
+
+							//Low 16 bits have same meaning as 23, 22, 19, 12:0 from normal card status
+
+							if(s.m_data & 0x00008000)
+								ret += "COM_CRC_ERROR ";
+							if(s.m_data & 0x00004000)
+								ret += "ILLEGAL_COMMAND ";
+							if(s.m_data & 0x00002000)
+								ret += "ERROR ";
+							if(s.m_data & 0x00000100)
+								ret += "READY_FOR_DATA ";
+							if(s.m_data & 0x00000040)
+								ret += "FX_EVENT ";
+							if(s.m_data & 0x00000020)
+								ret += "APP_CMD ";
+							if(s.m_data & 0x00000010)
+								ret += "RESERVED_SDIO ";
+							if(s.m_data & 0x00000008)
+								ret += "AKE_SEQ_ERR ";
+							if(s.m_data & 0x00060084)
+								ret += "RESERVED ";
+
+							//12:9 CURRENT_STATE
+							uint32_t state = (s.m_data >> 9) & 0xf;
+							switch(state)
+							{
+								case 0:
+									ret += "idle";
+									break;
+
+								case 1:
+									ret += "ready";
+									break;
+
+								case 2:
+									ret += "ident";
+									break;
+
+								case 3:
+									ret += "stby";
+									break;
+
+								case 4:
+									ret += "tran";
+									break;
+
+								case 5:
+									ret += "data";
+									break;
+
+								case 6:
+									ret += "rcv";
+									break;
+
+								case 7:
+									ret += "prg";
+									break;
+
+								case 8:
+									ret += "dis";
+									break;
+
+								default:
+									ret += "reserved_state";
+							}
+						}
+						break;
+
+
+					//SD: R7 Card Interface Condition (4.9.6)
+					//eMMC: Extended CSD (reply is a block of data on the data pins)
+					case 8:
+						if(cardtype == SDCmdDecoder::SD_EMMC)
+							ret = "";
+						else
+						{
+							snprintf(tmp, sizeof(tmp), "%02x", s.m_data & 0xff);
+							ret = string("Check ") + tmp;
+
+							if(s.m_data & 0x2000)
+								ret += " 1V2 ";
+							if(s.m_data & 0x1000)
+								ret += " PCIe ";
+
+							int voltage = (s.m_data >> 8) & 0xf;
+							if(voltage == 1)
+								ret += " 3V3";
+							else
+								ret += " Vunknown";
+
+						}
+						break;
+
+					//R3 OCR Register (4.9.4, 5.1). Operation Conditions Register Register :)
+					case 141:
+						{
+							ret = "";
+							if( (s.m_data & 0x80000000) == 0)
+								ret += "BUSY ";
+
+							//CCS bit is only valid after powerup is complete
+							else
+							{
+								if(s.m_data & 0x08000000)
+									ret += "UC";
+								else if(s.m_data & 0x40000000)
+									ret += "HC/XC ";
+								else
+									ret += "SC ";
+							}
+
+							if(s.m_data & 0x01000000)
+								ret += "S18A ";
+
+							//VDD voltage window
+							uint32_t window = s.m_data & 0xffffff;
+							if(window == 0)
+								ret += "Voltage?";
+							else
+							{
+								float vmax = 0;
+								float vmin = 3.6;
+
+								if(window & 0x00800000)
+								{
+									vmax = max(vmax, 3.6f);
+									vmin = min(vmin, 3.5f);
+								}
+								if(window & 0x00400000)
+								{
+									vmax = max(vmax, 3.5f);
+									vmin = min(vmin, 3.4f);
+								}
+								if(window & 0x00200000)
+								{
+									vmax = max(vmax, 3.4f);
+									vmin = min(vmin, 3.3f);
+								}
+								if(window & 0x00100000)
+								{
+									vmax = max(vmax, 3.3f);
+									vmin = min(vmin, 3.2f);
+								}
+								if(window & 0x00080000)
+								{
+									vmax = max(vmax, 3.2f);
+									vmin = min(vmin, 3.1f);
+								}
+								if(window & 0x00040000)
+								{
+									vmax = max(vmax, 3.1f);
+									vmin = min(vmin, 3.0f);
+								}
+								if(window & 0x00020000)
+								{
+									vmax = max(vmax, 3.0f);
+									vmin = min(vmin, 2.9f);
+								}
+								if(window & 0x00010000)
+								{
+									vmax = max(vmax, 2.9f);
+									vmin = min(vmin, 2.8f);
+								}
+								if(window & 0x00008000)
+								{
+									vmax = max(vmax, 2.8f);
+									vmin = min(vmin, 2.7f);
+								}
+
+								snprintf(tmp, sizeof(tmp), "Vdd = %.1f - %.1f", vmin, vmax);
+								ret += tmp;
+							}
+						}
+						break;
+
+					//Parse anything else as R1 Card Status (4.10)
+					default:
+						{
+							ret = "";
+							if(s.m_data & 0x80000000)
+								ret += "OUT_OF_RANGE ";
+							if(s.m_data & 0x40000000)
+								ret += "ADDRESS_ERROR ";
+							if(s.m_data & 0x20000000)
+								ret += "BLOCK_LEN_ERROR ";
+							if(s.m_data & 0x10000000)
+								ret += "ERASE_SEQ_ERROR ";
+							if(s.m_data & 0x08000000)
+								ret += "ERASE_PARAM ";
+							if(s.m_data & 0x04000000)
+								ret += "WP_VIOLATION ";
+							if(s.m_data & 0x02000000)
+								ret += "CARD_IS_LOCKED ";
+							if(s.m_data & 0x01000000)
+								ret += "LOCK_UNLOCK_FAILED ";
+							if(s.m_data & 0x00800000)
+								ret += "COM_CRC_ERROR ";
+							if(s.m_data & 0x00400000)
+								ret += "ILLEGAL_COMMAND ";
+							if(s.m_data & 0x00200000)
+								ret += "CARD_ECC_FAILED ";
+							if(s.m_data & 0x00100000)
+								ret += "CC_ERROR ";
+							if(s.m_data & 0x00080000)
+								ret += "ERROR ";
+							if(s.m_data & 0x00010000)
+								ret += "CSD_OVERWRITE ";
+							if(s.m_data & 0x00008000)
+								ret += "WP_ERASE_SKIP ";
+							if(s.m_data & 0x00004000)
+								ret += "CARD_ECC_DISABLED ";
+							if(s.m_data & 0x00002000)
+								ret += "ERASE_RESET ";
+							if(s.m_data & 0x00000100)
+								ret += "READY_FOR_DATA ";
+							if(s.m_data & 0x00000040)
+								ret += "FX_EVENT ";
+							if(s.m_data & 0x00000020)
+								ret += "APP_CMD ";
+							if(s.m_data & 0x00000010)
+								ret += "RESERVED_SDIO ";
+							if(s.m_data & 0x00000008)
+								ret += "AKE_SEQ_ERR ";
+							if(s.m_data & 0x00060084)
+								ret += "RESERVED ";
+
+							//12:9 CURRENT_STATE
+							uint32_t state = (s.m_data >> 9) & 0xf;
+							switch(state)
+							{
+								case 0:
+									ret += "idle";
+									break;
+
+								case 1:
+									ret += "ready";
+									break;
+
+								case 2:
+									ret += "ident";
+									break;
+
+								case 3:
+									ret += "stby";
+									break;
+
+								case 4:
+									ret += "tran";
+									break;
+
+								case 5:
+									ret += "data";
+									break;
+
+								case 6:
+									ret += "rcv";
+									break;
+
+								case 7:
+									ret += "prg";
+									break;
+
+								case 8:
+									ret += "dis";
+									break;
+
+								default:
+									ret += "reserved_state";
+							}
+						}
+						break;
+				}
+
+				return ret;
+			}
+
+		case SDCmdSymbol::TYPE_CRC_OK:
+		case SDCmdSymbol::TYPE_CRC_BAD:
+			snprintf(tmp, sizeof(tmp), "CRC: %02x", s.m_data);
+			return string(tmp);
+
+		case SDCmdSymbol::TYPE_ERROR:
+		default:
+			return "ERROR";
 	}
+
 	return "";
 }
 

--- a/scopeprotocols/SDCmdDecoder.h
+++ b/scopeprotocols/SDCmdDecoder.h
@@ -94,9 +94,6 @@ public:
 
 	static std::string GetProtocolName();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual bool GetShowDataColumn();
 
 	std::vector<std::string> GetHeaders();

--- a/scopeprotocols/SDCmdDecoder.h
+++ b/scopeprotocols/SDCmdDecoder.h
@@ -94,8 +94,8 @@ public:
 
 	static std::string GetProtocolName();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual bool GetShowDataColumn();
 

--- a/scopeprotocols/SDCmdDecoder.h
+++ b/scopeprotocols/SDCmdDecoder.h
@@ -79,7 +79,15 @@ public:
 	}
 };
 
-typedef Waveform<SDCmdSymbol> SDCmdWaveform;
+class SDCmdWaveform : public Waveform<SDCmdSymbol>
+{
+public:
+	SDCmdWaveform (FilterParameter& cardTypeParam) : Waveform<SDCmdSymbol>(), m_cardTypeParam(cardTypeParam) {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+
+	FilterParameter& m_cardTypeParam;
+};
 
 
 /**

--- a/scopeprotocols/SDDataDecoder.cpp
+++ b/scopeprotocols/SDDataDecoder.cpp
@@ -262,23 +262,23 @@ Gdk::Color SDDataDecoder::GetColor(size_t i, size_t /*stream*/)
 		{
 			case SDDataSymbol::TYPE_START:
 			case SDDataSymbol::TYPE_END:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case SDDataSymbol::TYPE_CRC_OK:
-				return m_standardColors[COLOR_CHECKSUM_OK];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 			case SDDataSymbol::TYPE_CRC_BAD:
-				return m_standardColors[COLOR_CHECKSUM_BAD];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
 
 			case SDDataSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case SDDataSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string SDDataDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/SDDataDecoder.cpp
+++ b/scopeprotocols/SDDataDecoder.cpp
@@ -252,64 +252,54 @@ void SDDataDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color SDDataDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color SDDataWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<SDDataWaveform*>(GetData(0));
-	if(capture != NULL)
+	const SDDataSymbol& s = m_samples[i];
+	switch(s.m_stype)
 	{
-		const SDDataSymbol& s = capture->m_samples[i];
-		switch(s.m_stype)
-		{
-			case SDDataSymbol::TYPE_START:
-			case SDDataSymbol::TYPE_END:
-				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
+		case SDDataSymbol::TYPE_START:
+		case SDDataSymbol::TYPE_END:
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
-			case SDDataSymbol::TYPE_CRC_OK:
-				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
+		case SDDataSymbol::TYPE_CRC_OK:
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
-			case SDDataSymbol::TYPE_CRC_BAD:
-				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
+		case SDDataSymbol::TYPE_CRC_BAD:
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
 
-			case SDDataSymbol::TYPE_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
+		case SDDataSymbol::TYPE_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-			case SDDataSymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case SDDataSymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string SDDataDecoder::GetText(size_t i, size_t /*stream*/)
+string SDDataWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<SDDataWaveform*>(GetData(0));
-	if(capture != NULL)
+	const SDDataSymbol& s = m_samples[i];
+	char tmp[32];
+	switch(s.m_stype)
 	{
-		const SDDataSymbol& s = capture->m_samples[i];
-		char tmp[32];
-		switch(s.m_stype)
-		{
-			case SDDataSymbol::TYPE_START:
-				return "START";
+		case SDDataSymbol::TYPE_START:
+			return "START";
 
-			case SDDataSymbol::TYPE_END:
-				return "END";
+		case SDDataSymbol::TYPE_END:
+			return "END";
 
-			case SDDataSymbol::TYPE_CRC_OK:
-			case SDDataSymbol::TYPE_CRC_BAD:
-				return "CRC FIXME";
+		case SDDataSymbol::TYPE_CRC_OK:
+		case SDDataSymbol::TYPE_CRC_BAD:
+			return "CRC FIXME";
 
-			case SDDataSymbol::TYPE_DATA:
-				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				return string(tmp);
+		case SDDataSymbol::TYPE_DATA:
+			snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			return string(tmp);
 
-			case SDDataSymbol::TYPE_ERROR:
-			default:
-				return "ERROR";
-		}
+		case SDDataSymbol::TYPE_ERROR:
+		default:
+			return "ERROR";
 	}
-	return "";
 }
 
 vector<string> SDDataDecoder::GetHeaders()

--- a/scopeprotocols/SDDataDecoder.h
+++ b/scopeprotocols/SDDataDecoder.h
@@ -82,9 +82,6 @@ public:
 
 	static std::string GetProtocolName();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
 
 	PROTOCOL_DECODER_INITPROC(SDDataDecoder)

--- a/scopeprotocols/SDDataDecoder.h
+++ b/scopeprotocols/SDDataDecoder.h
@@ -69,7 +69,13 @@ public:
 	}
 };
 
-typedef Waveform<SDDataSymbol> SDDataWaveform;
+class SDDataWaveform : public Waveform<SDDataSymbol>
+{
+public:
+	SDDataWaveform () : Waveform<SDDataSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class SDDataDecoder : public PacketDecoder
 {

--- a/scopeprotocols/SDDataDecoder.h
+++ b/scopeprotocols/SDDataDecoder.h
@@ -82,8 +82,8 @@ public:
 
 	static std::string GetProtocolName();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
 

--- a/scopeprotocols/SDRAMDecoderBase.cpp
+++ b/scopeprotocols/SDRAMDecoderBase.cpp
@@ -63,23 +63,23 @@ Gdk::Color SDRAMDecoderBase::GetColor(size_t i, size_t /*stream*/)
 			case SDRAMSymbol::TYPE_PRE:
 			case SDRAMSymbol::TYPE_PREA:
 			case SDRAMSymbol::TYPE_STOP:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case SDRAMSymbol::TYPE_ACT:
 			case SDRAMSymbol::TYPE_WR:
 			case SDRAMSymbol::TYPE_WRA:
 			case SDRAMSymbol::TYPE_RD:
 			case SDRAMSymbol::TYPE_RDA:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case SDRAMSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
 	//error
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string SDRAMDecoderBase::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/SDRAMDecoderBase.cpp
+++ b/scopeprotocols/SDRAMDecoderBase.cpp
@@ -49,82 +49,70 @@ SDRAMDecoderBase::~SDRAMDecoderBase()
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Pretty printing
 
-Gdk::Color SDRAMDecoderBase::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color SDRAMWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<SDRAMWaveform*>(GetData(0));
-	if(capture != NULL)
+	const SDRAMSymbol& s = m_samples[i];
+
+	switch(s.m_stype)
 	{
-		const SDRAMSymbol& s = capture->m_samples[i];
+		case SDRAMSymbol::TYPE_MRS:
+		case SDRAMSymbol::TYPE_REF:
+		case SDRAMSymbol::TYPE_PRE:
+		case SDRAMSymbol::TYPE_PREA:
+		case SDRAMSymbol::TYPE_STOP:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-		switch(s.m_stype)
-		{
-			case SDRAMSymbol::TYPE_MRS:
-			case SDRAMSymbol::TYPE_REF:
-			case SDRAMSymbol::TYPE_PRE:
-			case SDRAMSymbol::TYPE_PREA:
-			case SDRAMSymbol::TYPE_STOP:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+		case SDRAMSymbol::TYPE_ACT:
+		case SDRAMSymbol::TYPE_WR:
+		case SDRAMSymbol::TYPE_WRA:
+		case SDRAMSymbol::TYPE_RD:
+		case SDRAMSymbol::TYPE_RDA:
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
-			case SDRAMSymbol::TYPE_ACT:
-			case SDRAMSymbol::TYPE_WR:
-			case SDRAMSymbol::TYPE_WRA:
-			case SDRAMSymbol::TYPE_RD:
-			case SDRAMSymbol::TYPE_RDA:
-				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
-
-			case SDRAMSymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case SDRAMSymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	//error
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string SDRAMDecoderBase::GetText(size_t i, size_t /*stream*/)
+string SDRAMWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<SDRAMWaveform*>(GetData(0));
-	if(capture != NULL)
+	const SDRAMSymbol& s = m_samples[i];
+
+	switch(s.m_stype)
 	{
-		const SDRAMSymbol& s = capture->m_samples[i];
+		case SDRAMSymbol::TYPE_MRS:
+			return "MRS";
 
-		switch(s.m_stype)
-		{
-			case SDRAMSymbol::TYPE_MRS:
-				return "MRS";
+		case SDRAMSymbol::TYPE_REF:
+			return "REF";
 
-			case SDRAMSymbol::TYPE_REF:
-				return "REF";
+		case SDRAMSymbol::TYPE_PRE:
+			return "PRE";
 
-			case SDRAMSymbol::TYPE_PRE:
-				return "PRE";
+		case SDRAMSymbol::TYPE_PREA:
+			return "PREA";
 
-			case SDRAMSymbol::TYPE_PREA:
-				return "PREA";
+		case SDRAMSymbol::TYPE_STOP:
+			return "STOP";
 
-			case SDRAMSymbol::TYPE_STOP:
-				return "STOP";
+		case SDRAMSymbol::TYPE_ACT:
+			return "ACT";
 
-			case SDRAMSymbol::TYPE_ACT:
-				return "ACT";
+		case SDRAMSymbol::TYPE_WR:
+			return "WR";
 
-			case SDRAMSymbol::TYPE_WR:
-				return "WR";
+		case SDRAMSymbol::TYPE_WRA:
+			return "WRA";
 
-			case SDRAMSymbol::TYPE_WRA:
-				return "WRA";
+		case SDRAMSymbol::TYPE_RD:
+			return "RD";
 
-			case SDRAMSymbol::TYPE_RD:
-				return "RD";
+		case SDRAMSymbol::TYPE_RDA:
+			return "RDA";
 
-			case SDRAMSymbol::TYPE_RDA:
-				return "RDA";
-
-			case SDRAMSymbol::TYPE_ERROR:
-			default:
-				return "ERR";
-		}
+		case SDRAMSymbol::TYPE_ERROR:
+		default:
+			return "ERR";
 	}
-	return "";
 }

--- a/scopeprotocols/SDRAMDecoderBase.h
+++ b/scopeprotocols/SDRAMDecoderBase.h
@@ -78,9 +78,6 @@ class SDRAMDecoderBase : public Filter
 public:
 	SDRAMDecoderBase(const std::string& color);
 	virtual ~SDRAMDecoderBase();
-
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
 };
 
 #endif

--- a/scopeprotocols/SDRAMDecoderBase.h
+++ b/scopeprotocols/SDRAMDecoderBase.h
@@ -71,7 +71,13 @@ public:
 	}
 };
 
-typedef Waveform<SDRAMSymbol> SDRAMWaveform;
+class SDRAMWaveform : public Waveform<SDRAMSymbol>
+{
+public:
+	SDRAMWaveform () : Waveform<SDRAMSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class SDRAMDecoderBase : public Filter
 {

--- a/scopeprotocols/SDRAMDecoderBase.h
+++ b/scopeprotocols/SDRAMDecoderBase.h
@@ -79,8 +79,8 @@ public:
 	SDRAMDecoderBase(const std::string& color);
 	virtual ~SDRAMDecoderBase();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 };
 
 #endif

--- a/scopeprotocols/SPIDecoder.cpp
+++ b/scopeprotocols/SPIDecoder.cpp
@@ -248,49 +248,39 @@ void SPIDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color SPIDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color SPIWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<SPIWaveform*>(GetData(0));
-	if(capture != NULL)
+	const SPISymbol& s = m_samples[i];
+	switch(s.m_stype)
 	{
-		const SPISymbol& s = capture->m_samples[i];
-		switch(s.m_stype)
-		{
-			case SPISymbol::TYPE_SELECT:
-			case SPISymbol::TYPE_DESELECT:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+		case SPISymbol::TYPE_SELECT:
+		case SPISymbol::TYPE_DESELECT:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case SPISymbol::TYPE_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
+		case SPISymbol::TYPE_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-			case SPISymbol::TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case SPISymbol::TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string SPIDecoder::GetText(size_t i, size_t /*stream*/)
+string SPIWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<SPIWaveform*>(GetData(0));
-	if(capture != NULL)
+	const SPISymbol& s = m_samples[i];
+	char tmp[32];
+	switch(s.m_stype)
 	{
-		const SPISymbol& s = capture->m_samples[i];
-		char tmp[32];
-		switch(s.m_stype)
-		{
-			case SPISymbol::TYPE_SELECT:
-				return "SELECT";
-			case SPISymbol::TYPE_DESELECT:
-				return "DESELECT";
-			case SPISymbol::TYPE_DATA:
-				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				return string(tmp);
-			case SPISymbol::TYPE_ERROR:
-			default:
-				return "ERROR";
-		}
+		case SPISymbol::TYPE_SELECT:
+			return "SELECT";
+		case SPISymbol::TYPE_DESELECT:
+			return "DESELECT";
+		case SPISymbol::TYPE_DATA:
+			snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			return string(tmp);
+		case SPISymbol::TYPE_ERROR:
+		default:
+			return "ERROR";
 	}
-	return "";
 }

--- a/scopeprotocols/SPIDecoder.cpp
+++ b/scopeprotocols/SPIDecoder.cpp
@@ -258,17 +258,17 @@ Gdk::Color SPIDecoder::GetColor(size_t i, size_t /*stream*/)
 		{
 			case SPISymbol::TYPE_SELECT:
 			case SPISymbol::TYPE_DESELECT:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case SPISymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case SPISymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string SPIDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/SPIDecoder.h
+++ b/scopeprotocols/SPIDecoder.h
@@ -71,8 +71,8 @@ class SPIDecoder : public Filter
 public:
 	SPIDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/SPIDecoder.h
+++ b/scopeprotocols/SPIDecoder.h
@@ -64,7 +64,13 @@ public:
 	}
 };
 
-typedef Waveform<SPISymbol> SPIWaveform;
+class SPIWaveform : public Waveform<SPISymbol>
+{
+public:
+	SPIWaveform () : Waveform<SPISymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class SPIDecoder : public Filter
 {

--- a/scopeprotocols/SPIDecoder.h
+++ b/scopeprotocols/SPIDecoder.h
@@ -71,9 +71,6 @@ class SPIDecoder : public Filter
 public:
 	SPIDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/SPIFlashDecoder.cpp
+++ b/scopeprotocols/SPIFlashDecoder.cpp
@@ -609,7 +609,7 @@ void SPIFlashDecoder::Refresh()
 					cap->m_durations.push_back(din->m_durations[iin]);
 					cap->m_samples.push_back(SPIFlashSymbol(SPIFlashSymbol::TYPE_COMMAND, current_cmd, 0));
 
-					pack->m_headers["Op"] = GetText(cap->m_samples.size() - 1, 0);
+					pack->m_headers["Op"] = cap->GetText(cap->m_samples.size() - 1);
 				}
 				break;
 
@@ -833,7 +833,7 @@ void SPIFlashDecoder::Refresh()
 							pack->m_headers["Address"] = tmp;
 						}
 						else
-							pack->m_headers["Address"] = GetText(cap->m_samples.size() - 1, 0);
+							pack->m_headers["Address"] = cap->GetText(cap->m_samples.size() - 1);
 					}
 				}
 
@@ -850,12 +850,12 @@ void SPIFlashDecoder::Refresh()
 						if(data_type == SPIFlashSymbol::TYPE_PART_ID)
 						{
 							pack->m_headers["Info"] +=
-								GetText(cap->m_samples.size()-2, 0) +
+								cap->GetText(cap->m_samples.size()-2) +
 								" " +
-								GetText(cap->m_samples.size()-1, 0);
+								cap->GetText(cap->m_samples.size()-1);
 						}
 						else
-							pack->m_headers["Info"] = GetText(cap->m_samples.size()-1, 0);
+							pack->m_headers["Info"] = cap->GetText(cap->m_samples.size()-1);
 					}
 
 					//Only write to the output for actual flash data!
@@ -976,7 +976,7 @@ void SPIFlashDecoder::Refresh()
 
 					//At the end of a write command, crack status registers if needed
 					if(data_type != SPIFlashSymbol::TYPE_DATA)
-						pack->m_headers["Info"] = GetText(cap->m_samples.size()-1, 0);
+						pack->m_headers["Info"] = cap->GetText(cap->m_samples.size()-1);
 				}
 				else
 				{
@@ -998,229 +998,218 @@ void SPIFlashDecoder::Refresh()
 	}
 }
 
-Gdk::Color SPIFlashDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color SPIFlashWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<SPIFlashWaveform*>(GetData(0));
-	if(capture != NULL)
+	const SPIFlashSymbol& s = m_samples[i];
+
+	switch(s.m_type)
 	{
-		const SPIFlashSymbol& s = capture->m_samples[i];
+		case SPIFlashSymbol::TYPE_DUMMY:
+			return StandardColors::colors[StandardColors::COLOR_IDLE];
 
-		switch(s.m_type)
-		{
-			case SPIFlashSymbol::TYPE_DUMMY:
-				return StandardColors::colors[StandardColors::COLOR_IDLE];
+		case SPIFlashSymbol::TYPE_COMMAND:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-			case SPIFlashSymbol::TYPE_COMMAND:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+		case SPIFlashSymbol::TYPE_ADDRESS:
+		case SPIFlashSymbol::TYPE_W25N_SR_ADDR:
+		case SPIFlashSymbol::TYPE_W25N_BLOCK_ADDR:
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
-			case SPIFlashSymbol::TYPE_ADDRESS:
-			case SPIFlashSymbol::TYPE_W25N_SR_ADDR:
-			case SPIFlashSymbol::TYPE_W25N_BLOCK_ADDR:
-				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
+		case SPIFlashSymbol::TYPE_DATA:
+		case SPIFlashSymbol::TYPE_VENDOR_ID:
+		case SPIFlashSymbol::TYPE_PART_ID:
+		case SPIFlashSymbol::TYPE_W25N_SR_CONFIG:
+		case SPIFlashSymbol::TYPE_W25N_SR_PROT:
+		case SPIFlashSymbol::TYPE_W25N_SR_STATUS:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-			case SPIFlashSymbol::TYPE_DATA:
-			case SPIFlashSymbol::TYPE_VENDOR_ID:
-			case SPIFlashSymbol::TYPE_PART_ID:
-			case SPIFlashSymbol::TYPE_W25N_SR_CONFIG:
-			case SPIFlashSymbol::TYPE_W25N_SR_PROT:
-			case SPIFlashSymbol::TYPE_W25N_SR_STATUS:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
-
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string SPIFlashDecoder::GetText(size_t i, size_t /*stream*/)
+string SPIFlashWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<SPIFlashWaveform*>(GetData(0));
-	if(capture != NULL)
+	const SPIFlashSymbol& s = m_samples[i];
+	char tmp[128];
+
+	switch(s.m_type)
 	{
-		const SPIFlashSymbol& s = capture->m_samples[i];
-		char tmp[128];
+		case SPIFlashSymbol::TYPE_DUMMY:
+			return "Wait state";
 
-		switch(s.m_type)
-		{
-			case SPIFlashSymbol::TYPE_DUMMY:
-				return "Wait state";
+		case SPIFlashSymbol::TYPE_VENDOR_ID:
+			switch(s.m_data)
+			{
+				case SPIFlashDecoder::VENDOR_ID_CYPRESS:
+					return "Cypress";
+				case SPIFlashDecoder::VENDOR_ID_MICRON:
+					return "Micron";
+				case SPIFlashDecoder::VENDOR_ID_WINBOND:
+					return "Winbond";
 
-			case SPIFlashSymbol::TYPE_VENDOR_ID:
-				switch(s.m_data)
+				default:
+					snprintf(tmp, sizeof(tmp), "0x%x", s.m_data);
+					break;
+			}
+			break;
+
+		//Part ID depends on vendor ID
+		case SPIFlashSymbol::TYPE_PART_ID:
+			return SPIFlashDecoder::GetPartID(this, s, i);
+
+		case SPIFlashSymbol::TYPE_COMMAND:
+			switch(s.m_cmd)
+			{
+				case SPIFlashSymbol::CMD_READ:
+					return "Read";
+				case SPIFlashSymbol::CMD_READ_SFDP:
+					return "Read SFDP";
+				case SPIFlashSymbol::CMD_FAST_READ:
+					return "Read Fast";
+				case SPIFlashSymbol::CMD_READ_1_1_4:
+					return "Read Quad";
+				case SPIFlashSymbol::CMD_READ_1_4_4:
+					return "Read Quad I/O";
+				case SPIFlashSymbol::CMD_READ_JEDEC_ID:
+					return "Read JEDEC ID";
+				case SPIFlashSymbol::CMD_READ_STATUS_REGISTER:
+					return "Read Status";
+				case SPIFlashSymbol::CMD_READ_STATUS_REGISTER_1:
+					return "Read Status Register 1";
+				case SPIFlashSymbol::CMD_READ_STATUS_REGISTER_2:
+					return "Read Status Register 2";
+				case SPIFlashSymbol::CMD_READ_STATUS_REGISTER_3:
+					return "Read Status Register 3";
+				case SPIFlashSymbol::CMD_WRITE_STATUS_REGISTER:
+					return "Write Status";
+				case SPIFlashSymbol::CMD_RESET:
+					return "Reset";
+				case SPIFlashSymbol::CMD_WRITE_DISABLE:
+					return "Write Disable";
+				case SPIFlashSymbol::CMD_WRITE_ENABLE:
+					return "Write Enable";
+				case SPIFlashSymbol::CMD_BLOCK_ERASE:
+					return "Block Erase";
+				case SPIFlashSymbol::CMD_PAGE_PROGRAM:
+					return "Page Program";
+				case SPIFlashSymbol::CMD_ADDR_24BIT:
+					return "Select 24-Bit Address";
+				case SPIFlashSymbol::CMD_ADDR_32BIT:
+					return "Select 32-Bit Address";
+				case SPIFlashSymbol::CMD_RELEASE_PD:
+					return "Release from Power Down";
+				case SPIFlashSymbol::CMD_ENABLE_RESET:
+					return "Enable Reset";
+
+				//W25N specific
+				case SPIFlashSymbol::CMD_W25N_PROGRAM_EXECUTE:
+					return "Program Execute";
+				case SPIFlashSymbol::CMD_W25N_READ_PAGE:
+					return "Read Page";
+
+				default:
+					return "Unknown Cmd";
+			}
+
+		case SPIFlashSymbol::TYPE_ADDRESS:
+			snprintf(tmp, sizeof(tmp), "Addr 0x%x", s.m_data);
+			break;
+
+		case SPIFlashSymbol::TYPE_DATA:
+			snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			break;
+
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////
+		// Winbond W25N specific
+
+		case SPIFlashSymbol::TYPE_W25N_BLOCK_ADDR:
+			snprintf(tmp, sizeof(tmp), "Block %x", s.m_data);
+			break;
+
+		//Address of a W25N status register
+		case SPIFlashSymbol::TYPE_W25N_SR_ADDR:
+			if( (s.m_data & 0xf0) == 0xa0)
+				return "Protection";
+			else if( (s.m_data & 0xf0) == 0xb0)
+				return "Config";
+			else if( (s.m_data & 0xf0) == 0xc0)
+				return "Status";
+			else
+				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			break;
+
+		//W25N status registers
+		case SPIFlashSymbol::TYPE_W25N_SR_CONFIG:
+			{
+				string ret = "";
+				if(s.m_data & 0x80)
+					ret += "OTP-LOCK ";
+				if(s.m_data & 0x40)
+					ret += "OTP-WR ";
+				if(s.m_data & 0x20)
+					ret += "SR1-LOCK ";
+				if(s.m_data & 0x10)
+					ret += "ECCEN ";
+				if(s.m_data & 0x08)
+					ret += "BUFFER ";
+				else
+					ret += "CONTINUOUS ";
+				return ret;
+			}
+			break;	//TYPE_W25N_SR_CONFIG
+
+		case SPIFlashSymbol::TYPE_W25N_SR_PROT:
+			return "TODO prot";
+			break;
+
+		case SPIFlashSymbol::TYPE_W25N_SR_STATUS:
+			{
+				string ret = "";
+				if(s.m_data & 0x40)
+					ret += "LUT-F ";
+
+				uint8_t eccstat = (s.m_data >> 3) & 3;
+				switch(eccstat)
 				{
-					case VENDOR_ID_CYPRESS:
-						return "Cypress";
-					case VENDOR_ID_MICRON:
-						return "Micron";
-					case VENDOR_ID_WINBOND:
-						return "Winbond";
+					case 0:
+						ret += "ECC-OK ";
+						break;
 
-					default:
-						snprintf(tmp, sizeof(tmp), "0x%x", s.m_data);
+					case 1:
+						ret += "ECC-CORR ";
+						break;
+
+					case 2:
+						ret += "ECC-UNCORR-SINGLE ";
+						break;
+
+					case 3:
+						ret += "ECC-UNCORR-MULTI ";
 						break;
 				}
-				break;
 
-			//Part ID depends on vendor ID
-			case SPIFlashSymbol::TYPE_PART_ID:
-				return GetPartID(capture, s, i);
+				if(s.m_data & 8)
+					ret += "PROG-FAIL ";
 
-			case SPIFlashSymbol::TYPE_COMMAND:
-				switch(s.m_cmd)
-				{
-					case SPIFlashSymbol::CMD_READ:
-						return "Read";
-					case SPIFlashSymbol::CMD_READ_SFDP:
-						return "Read SFDP";
-					case SPIFlashSymbol::CMD_FAST_READ:
-						return "Read Fast";
-					case SPIFlashSymbol::CMD_READ_1_1_4:
-						return "Read Quad";
-					case SPIFlashSymbol::CMD_READ_1_4_4:
-						return "Read Quad I/O";
-					case SPIFlashSymbol::CMD_READ_JEDEC_ID:
-						return "Read JEDEC ID";
-					case SPIFlashSymbol::CMD_READ_STATUS_REGISTER:
-						return "Read Status";
-					case SPIFlashSymbol::CMD_READ_STATUS_REGISTER_1:
-						return "Read Status Register 1";
-					case SPIFlashSymbol::CMD_READ_STATUS_REGISTER_2:
-						return "Read Status Register 2";
-					case SPIFlashSymbol::CMD_READ_STATUS_REGISTER_3:
-						return "Read Status Register 3";
-					case SPIFlashSymbol::CMD_WRITE_STATUS_REGISTER:
-						return "Write Status";
-					case SPIFlashSymbol::CMD_RESET:
-						return "Reset";
-					case SPIFlashSymbol::CMD_WRITE_DISABLE:
-						return "Write Disable";
-					case SPIFlashSymbol::CMD_WRITE_ENABLE:
-						return "Write Enable";
-					case SPIFlashSymbol::CMD_BLOCK_ERASE:
-						return "Block Erase";
-					case SPIFlashSymbol::CMD_PAGE_PROGRAM:
-						return "Page Program";
-					case SPIFlashSymbol::CMD_ADDR_24BIT:
-						return "Select 24-Bit Address";
-					case SPIFlashSymbol::CMD_ADDR_32BIT:
-						return "Select 32-Bit Address";
-					case SPIFlashSymbol::CMD_RELEASE_PD:
-						return "Release from Power Down";
-					case SPIFlashSymbol::CMD_ENABLE_RESET:
-						return "Enable Reset";
+				if(s.m_data & 4)
+					ret += "ERASE-FAIL ";
 
-					//W25N specific
-					case SPIFlashSymbol::CMD_W25N_PROGRAM_EXECUTE:
-						return "Program Execute";
-					case SPIFlashSymbol::CMD_W25N_READ_PAGE:
-						return "Read Page";
+				if(s.m_data & 2)
+					ret += "WRITABLE ";
 
-					default:
-						return "Unknown Cmd";
-				}
+				if(s.m_data & 1)
+					ret += "BUSY";
 
-			case SPIFlashSymbol::TYPE_ADDRESS:
-				snprintf(tmp, sizeof(tmp), "Addr 0x%x", s.m_data);
-				break;
+				return ret;
+			}
+			break;	//TYPE_W25N_SR_STATUS
 
-			case SPIFlashSymbol::TYPE_DATA:
-				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				break;
-
-			////////////////////////////////////////////////////////////////////////////////////////////////////////////
-			// Winbond W25N specific
-
-			case SPIFlashSymbol::TYPE_W25N_BLOCK_ADDR:
-				snprintf(tmp, sizeof(tmp), "Block %x", s.m_data);
-				break;
-
-			//Address of a W25N status register
-			case SPIFlashSymbol::TYPE_W25N_SR_ADDR:
-				if( (s.m_data & 0xf0) == 0xa0)
-					return "Protection";
-				else if( (s.m_data & 0xf0) == 0xb0)
-					return "Config";
-				else if( (s.m_data & 0xf0) == 0xc0)
-					return "Status";
-				else
-					snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				break;
-
-			//W25N status registers
-			case SPIFlashSymbol::TYPE_W25N_SR_CONFIG:
-				{
-					string ret = "";
-					if(s.m_data & 0x80)
-						ret += "OTP-LOCK ";
-					if(s.m_data & 0x40)
-						ret += "OTP-WR ";
-					if(s.m_data & 0x20)
-						ret += "SR1-LOCK ";
-					if(s.m_data & 0x10)
-						ret += "ECCEN ";
-					if(s.m_data & 0x08)
-						ret += "BUFFER ";
-					else
-						ret += "CONTINUOUS ";
-					return ret;
-				}
-				break;	//TYPE_W25N_SR_CONFIG
-
-			case SPIFlashSymbol::TYPE_W25N_SR_PROT:
-				return "TODO prot";
-				break;
-
-			case SPIFlashSymbol::TYPE_W25N_SR_STATUS:
-				{
-					string ret = "";
-					if(s.m_data & 0x40)
-						ret += "LUT-F ";
-
-					uint8_t eccstat = (s.m_data >> 3) & 3;
-					switch(eccstat)
-					{
-						case 0:
-							ret += "ECC-OK ";
-							break;
-
-						case 1:
-							ret += "ECC-CORR ";
-							break;
-
-						case 2:
-							ret += "ECC-UNCORR-SINGLE ";
-							break;
-
-						case 3:
-							ret += "ECC-UNCORR-MULTI ";
-							break;
-					}
-
-					if(s.m_data & 8)
-						ret += "PROG-FAIL ";
-
-					if(s.m_data & 4)
-						ret += "ERASE-FAIL ";
-
-					if(s.m_data & 2)
-						ret += "WRITABLE ";
-
-					if(s.m_data & 1)
-						ret += "BUSY";
-
-					return ret;
-				}
-				break;	//TYPE_W25N_SR_STATUS
-
-			default:
-				return "ERROR";
-		}
-
-		return string(tmp);
+		default:
+			return "ERROR";
 	}
-	return "";
+
+	return string(tmp);
 }
 
 string SPIFlashDecoder::GetPartID(SPIFlashWaveform* cap, const SPIFlashSymbol& s, int i)

--- a/scopeprotocols/SPIFlashDecoder.cpp
+++ b/scopeprotocols/SPIFlashDecoder.cpp
@@ -1008,15 +1008,15 @@ Gdk::Color SPIFlashDecoder::GetColor(size_t i, size_t /*stream*/)
 		switch(s.m_type)
 		{
 			case SPIFlashSymbol::TYPE_DUMMY:
-				return m_standardColors[COLOR_IDLE];
+				return StandardColors::colors[StandardColors::COLOR_IDLE];
 
 			case SPIFlashSymbol::TYPE_COMMAND:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case SPIFlashSymbol::TYPE_ADDRESS:
 			case SPIFlashSymbol::TYPE_W25N_SR_ADDR:
 			case SPIFlashSymbol::TYPE_W25N_BLOCK_ADDR:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case SPIFlashSymbol::TYPE_DATA:
 			case SPIFlashSymbol::TYPE_VENDOR_ID:
@@ -1024,14 +1024,14 @@ Gdk::Color SPIFlashDecoder::GetColor(size_t i, size_t /*stream*/)
 			case SPIFlashSymbol::TYPE_W25N_SR_CONFIG:
 			case SPIFlashSymbol::TYPE_W25N_SR_PROT:
 			case SPIFlashSymbol::TYPE_W25N_SR_STATUS:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string SPIFlashDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/SPIFlashDecoder.h
+++ b/scopeprotocols/SPIFlashDecoder.h
@@ -119,8 +119,8 @@ public:
 	SPIFlashDecoder(const std::string& color);
 	virtual ~SPIFlashDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/SPIFlashDecoder.h
+++ b/scopeprotocols/SPIFlashDecoder.h
@@ -111,7 +111,13 @@ public:
 	}
 };
 
-typedef Waveform<SPIFlashSymbol> SPIFlashWaveform;
+class SPIFlashWaveform : public Waveform<SPIFlashSymbol>
+{
+public:
+	SPIFlashWaveform () : Waveform<SPIFlashSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class SPIFlashDecoder : public PacketDecoder
 {
@@ -146,9 +152,10 @@ public:
 
 	PROTOCOL_DECODER_INITPROC(SPIFlashDecoder)
 
-protected:
-	std::string GetPartID(SPIFlashWaveform* cap, const SPIFlashSymbol& s, int i);
 
+	static std::string GetPartID(SPIFlashWaveform* cap, const SPIFlashSymbol& s, int i);
+
+protected:
 	std::string m_typename;
 	std::string m_outfile;
 

--- a/scopeprotocols/SPIFlashDecoder.h
+++ b/scopeprotocols/SPIFlashDecoder.h
@@ -119,9 +119,6 @@ public:
 	SPIFlashDecoder(const std::string& color);
 	virtual ~SPIFlashDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	std::vector<std::string> GetHeaders();

--- a/scopeprotocols/SWDDecoder.cpp
+++ b/scopeprotocols/SWDDecoder.cpp
@@ -448,7 +448,7 @@ Gdk::Color SWDDecoder::GetColor(size_t i, size_t /*stream*/)
 			case SWDSymbol::TYPE_PARK:
 			case SWDSymbol::TYPE_TURNAROUND:
 			case SWDSymbol::TYPE_LINERESET:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case SWDSymbol::TYPE_SWDTOJTAG:
 			case SWDSymbol::TYPE_JTAGTOSWD:
@@ -456,37 +456,37 @@ Gdk::Color SWDDecoder::GetColor(size_t i, size_t /*stream*/)
 			case SWDSymbol::TYPE_LEAVEDORMANT:
 			case SWDSymbol::TYPE_AP_NDP:
 			case SWDSymbol::TYPE_R_NW:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case SWDSymbol::TYPE_ACK:
 				switch(s.m_data)
 				{
 					case 1:
 					case 2:
-						return m_standardColors[COLOR_CONTROL];
+						return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 					case 4:
 					default:
-						return m_standardColors[COLOR_ERROR];
+						return StandardColors::colors[StandardColors::COLOR_ERROR];
 				}
 
 			case SWDSymbol::TYPE_ADDRESS:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case SWDSymbol::TYPE_PARITY_OK:
-				return m_standardColors[COLOR_CHECKSUM_OK];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 			case SWDSymbol::TYPE_PARITY_BAD:
-				return m_standardColors[COLOR_CHECKSUM_BAD];
+				return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
 
 			case SWDSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case SWDSymbol::TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string SWDDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/SWDDecoder.h
+++ b/scopeprotocols/SWDDecoder.h
@@ -87,9 +87,6 @@ private:
 public:
 	SWDDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/SWDDecoder.h
+++ b/scopeprotocols/SWDDecoder.h
@@ -87,8 +87,8 @@ private:
 public:
 	SWDDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/SWDDecoder.h
+++ b/scopeprotocols/SWDDecoder.h
@@ -70,7 +70,13 @@ public:
 	bool operator==(const SWDSymbol& s) const { return (m_stype == s.m_stype) && (m_data == s.m_data); }
 };
 
-typedef Waveform<SWDSymbol> SWDWaveform;
+class SWDWaveform : public Waveform<SWDSymbol>
+{
+public:
+	SWDWaveform () : Waveform<SWDSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class SWDDecoder : public Filter
 {

--- a/scopeprotocols/SWDMemAPDecoder.cpp
+++ b/scopeprotocols/SWDMemAPDecoder.cpp
@@ -338,32 +338,20 @@ void SWDMemAPDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color SWDMemAPDecoder::GetColor(size_t /*i*/, size_t /*stream*/)
+Gdk::Color SWDMemAPWaveform::GetColor(size_t /*i*/)
 {
-	auto capture = dynamic_cast<SWDMemAPWaveform*>(GetData(0));
-	if(capture != NULL)
-	{
-		//const SWDMemAPSymbol& s = capture->m_samples[i];
-		return StandardColors::colors[StandardColors::COLOR_DATA];
-	}
-
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_DATA];
 }
 
-string SWDMemAPDecoder::GetText(size_t i, size_t /*stream*/)
+string SWDMemAPWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<SWDMemAPWaveform*>(GetData(0));
 	char tmp[128] = "";
-	if(capture != NULL)
-	{
-		const SWDMemAPSymbol& s = capture->m_samples[i];
+	const SWDMemAPSymbol& s = m_samples[i];
 
-		if(s.m_write)
-			snprintf(tmp, sizeof(tmp), "Write %08x: %08x", s.m_addr, s.m_data);
-		else
-			snprintf(tmp, sizeof(tmp), "Read %08x: %08x", s.m_addr, s.m_data);
-		return string(tmp);
-	}
+	if(s.m_write)
+		snprintf(tmp, sizeof(tmp), "Write %08x: %08x", s.m_addr, s.m_data);
+	else
+		snprintf(tmp, sizeof(tmp), "Read %08x: %08x", s.m_addr, s.m_data);
 
 	return string(tmp);
 }

--- a/scopeprotocols/SWDMemAPDecoder.cpp
+++ b/scopeprotocols/SWDMemAPDecoder.cpp
@@ -344,10 +344,10 @@ Gdk::Color SWDMemAPDecoder::GetColor(size_t /*i*/, size_t /*stream*/)
 	if(capture != NULL)
 	{
 		//const SWDMemAPSymbol& s = capture->m_samples[i];
-		return m_standardColors[COLOR_DATA];
+		return StandardColors::colors[StandardColors::COLOR_DATA];
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string SWDMemAPDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/SWDMemAPDecoder.h
+++ b/scopeprotocols/SWDMemAPDecoder.h
@@ -67,9 +67,6 @@ class SWDMemAPDecoder : public PacketDecoder
 public:
 	SWDMemAPDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/SWDMemAPDecoder.h
+++ b/scopeprotocols/SWDMemAPDecoder.h
@@ -60,7 +60,13 @@ public:
 	}
 };
 
-typedef Waveform<SWDMemAPSymbol> SWDMemAPWaveform;
+class SWDMemAPWaveform : public Waveform<SWDMemAPSymbol>
+{
+public:
+	SWDMemAPWaveform () : Waveform<SWDMemAPSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class SWDMemAPDecoder : public PacketDecoder
 {

--- a/scopeprotocols/SWDMemAPDecoder.h
+++ b/scopeprotocols/SWDMemAPDecoder.h
@@ -67,8 +67,8 @@ class SWDMemAPDecoder : public PacketDecoder
 public:
 	SWDMemAPDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/TCPDecoder.cpp
+++ b/scopeprotocols/TCPDecoder.cpp
@@ -392,15 +392,9 @@ void TCPDecoder::Refresh()
 	//TODO: packet decode too
 }
 
-Gdk::Color TCPDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color TCPWaveform::GetColor(size_t i)
 {
-	auto data = dynamic_cast<TCPWaveform*>(GetData(0));
-	if(data == NULL)
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-	if(i >= data->m_samples.size())
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-
-	switch(data->m_samples[i].m_type)
+	switch(m_samples[i].m_type)
 	{
 		case TCPSymbol::TYPE_SEQ:
 		case TCPSymbol::TYPE_ACK:
@@ -428,16 +422,10 @@ Gdk::Color TCPDecoder::GetColor(size_t i, size_t /*stream*/)
 	}
 }
 
-string TCPDecoder::GetText(size_t i, size_t /*stream*/)
+string TCPWaveform::GetText(size_t i)
 {
-	auto data = dynamic_cast<TCPWaveform*>(GetData(0));
-	if(data == NULL)
-		return "";
-	if(i >= data->m_samples.size())
-		return "";
-
 	char tmp[128];
-	auto sample = data->m_samples[i];
+	auto sample = m_samples[i];
 
 	switch(sample.m_type)
 	{

--- a/scopeprotocols/TCPDecoder.cpp
+++ b/scopeprotocols/TCPDecoder.cpp
@@ -396,9 +396,9 @@ Gdk::Color TCPDecoder::GetColor(size_t i, size_t /*stream*/)
 {
 	auto data = dynamic_cast<TCPWaveform*>(GetData(0));
 	if(data == NULL)
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 	if(i >= data->m_samples.size())
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 	switch(data->m_samples[i].m_type)
 	{
@@ -409,22 +409,22 @@ Gdk::Color TCPDecoder::GetColor(size_t i, size_t /*stream*/)
 		case TCPSymbol::TYPE_WINDOW:
 		case TCPSymbol::TYPE_URGENT:
 		case TCPSymbol::TYPE_OPTIONS:
-			return m_standardColors[COLOR_CONTROL];
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 		//TODO: properly verify checksum
 		case TCPSymbol::TYPE_CHECKSUM:
-			return m_standardColors[COLOR_CHECKSUM_OK];
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 		case TCPSymbol::TYPE_SOURCE_PORT:
 		case TCPSymbol::TYPE_DEST_PORT:
-			return m_standardColors[COLOR_ADDRESS];
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 		case TCPSymbol::TYPE_DATA:
-			return m_standardColors[COLOR_DATA];
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
 		case TCPSymbol::TYPE_ERROR:
 		default:
-			return m_standardColors[COLOR_ERROR];
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
 }
 

--- a/scopeprotocols/TCPDecoder.h
+++ b/scopeprotocols/TCPDecoder.h
@@ -79,8 +79,8 @@ class TCPDecoder : public Filter
 public:
 	TCPDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/TCPDecoder.h
+++ b/scopeprotocols/TCPDecoder.h
@@ -72,7 +72,13 @@ public:
 	}
 };
 
-typedef Waveform<TCPSymbol> TCPWaveform;
+class TCPWaveform : public Waveform<TCPSymbol>
+{
+public:
+	TCPWaveform () : Waveform<TCPSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class TCPDecoder : public Filter
 {

--- a/scopeprotocols/TCPDecoder.h
+++ b/scopeprotocols/TCPDecoder.h
@@ -79,9 +79,6 @@ class TCPDecoder : public Filter
 public:
 	TCPDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/TMDSDecoder.cpp
+++ b/scopeprotocols/TMDSDecoder.cpp
@@ -257,22 +257,22 @@ Gdk::Color TMDSDecoder::GetColor(size_t i, size_t /*stream*/)
 		switch(s.m_type)
 		{
 			case TMDSSymbol::TMDS_TYPE_CONTROL:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case TMDSSymbol::TMDS_TYPE_GUARD:
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 			case TMDSSymbol::TMDS_TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			case TMDSSymbol::TMDS_TYPE_ERROR:
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
 	//error
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string TMDSDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/TMDSDecoder.cpp
+++ b/scopeprotocols/TMDSDecoder.cpp
@@ -247,61 +247,49 @@ void TMDSDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color TMDSDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color TMDSWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<TMDSWaveform*>(GetData(0));
-	if(capture != NULL)
+	const TMDSSymbol& s = m_samples[i];
+
+	switch(s.m_type)
 	{
-		const TMDSSymbol& s = capture->m_samples[i];
+		case TMDSSymbol::TMDS_TYPE_CONTROL:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
-		switch(s.m_type)
-		{
-			case TMDSSymbol::TMDS_TYPE_CONTROL:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+		case TMDSSymbol::TMDS_TYPE_GUARD:
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
-			case TMDSSymbol::TMDS_TYPE_GUARD:
-				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
+		case TMDSSymbol::TMDS_TYPE_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
-			case TMDSSymbol::TMDS_TYPE_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
-
-			case TMDSSymbol::TMDS_TYPE_ERROR:
-			default:
-				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
+		case TMDSSymbol::TMDS_TYPE_ERROR:
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
-
-	//error
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
-string TMDSDecoder::GetText(size_t i, size_t /*stream*/)
+string TMDSWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<TMDSWaveform*>(GetData(0));
-	if(capture != NULL)
+	const TMDSSymbol& s = m_samples[i];
+
+	char tmp[32];
+	switch(s.m_type)
 	{
-		const TMDSSymbol& s = capture->m_samples[i];
+		case TMDSSymbol::TMDS_TYPE_CONTROL:
+			snprintf(tmp, sizeof(tmp), "CTL%d", s.m_data);
+			break;
 
-		char tmp[32];
-		switch(s.m_type)
-		{
-			case TMDSSymbol::TMDS_TYPE_CONTROL:
-				snprintf(tmp, sizeof(tmp), "CTL%d", s.m_data);
-				break;
+		case TMDSSymbol::TMDS_TYPE_GUARD:
+			return "GB";
 
-			case TMDSSymbol::TMDS_TYPE_GUARD:
-				return "GB";
+		case TMDSSymbol::TMDS_TYPE_DATA:
+			snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
+			break;
 
-			case TMDSSymbol::TMDS_TYPE_DATA:
-				snprintf(tmp, sizeof(tmp), "%02x", s.m_data);
-				break;
+		case TMDSSymbol::TMDS_TYPE_ERROR:
+		default:
+			return "ERROR";
 
-			case TMDSSymbol::TMDS_TYPE_ERROR:
-			default:
-				return "ERROR";
-
-		}
-		return string(tmp);
 	}
-	return "";
+	return string(tmp);
 }

--- a/scopeprotocols/TMDSDecoder.h
+++ b/scopeprotocols/TMDSDecoder.h
@@ -72,8 +72,8 @@ class TMDSDecoder : public Filter
 public:
 	TMDSDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/TMDSDecoder.h
+++ b/scopeprotocols/TMDSDecoder.h
@@ -65,7 +65,13 @@ public:
 	}
 };
 
-typedef Waveform<TMDSSymbol> TMDSWaveform;
+class TMDSWaveform : public Waveform<TMDSSymbol>
+{
+public:
+	TMDSWaveform () : Waveform<TMDSSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class TMDSDecoder : public Filter
 {

--- a/scopeprotocols/TMDSDecoder.h
+++ b/scopeprotocols/TMDSDecoder.h
@@ -72,9 +72,6 @@ class TMDSDecoder : public Filter
 public:
 	TMDSDecoder(const std::string& color);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	static std::string GetProtocolName();

--- a/scopeprotocols/UARTDecoder.cpp
+++ b/scopeprotocols/UARTDecoder.cpp
@@ -104,7 +104,7 @@ void UARTDecoder::Refresh()
 	int64_t scaledbitper = ibitper / din->m_timescale;
 
 	//UART processing
-	auto cap = new ASCIIWaveform(m_displaycolor);
+	auto cap = new ByteWaveform(m_displaycolor);
 	cap->m_timescale = din->m_timescale;
 	cap->m_startTimestamp = din->m_startTimestamp;
 	cap->m_startFemtoseconds = din->m_startFemtoseconds;
@@ -223,12 +223,12 @@ void UARTDecoder::FinishPacket(Packet* pack)
 	m_packets.push_back(pack);
 }
 
-Gdk::Color ASCIIWaveform::GetColor(size_t /*i*/)
+Gdk::Color ByteWaveform::GetColor(size_t /*i*/)
 {
 	return Gdk::Color(m_color);
 }
 
-string ASCIIWaveform::GetText(size_t i)
+string ByteWaveform::GetText(size_t i)
 {
 	char c = m_samples[i];
 	char sbuf[16] = {0};

--- a/scopeprotocols/UARTDecoder.cpp
+++ b/scopeprotocols/UARTDecoder.cpp
@@ -104,7 +104,7 @@ void UARTDecoder::Refresh()
 	int64_t scaledbitper = ibitper / din->m_timescale;
 
 	//UART processing
-	auto cap = new UARTWaveform(m_displaycolor);
+	auto cap = new ASCIIWaveform(m_displaycolor);
 	cap->m_timescale = din->m_timescale;
 	cap->m_startTimestamp = din->m_startTimestamp;
 	cap->m_startFemtoseconds = din->m_startFemtoseconds;
@@ -223,12 +223,12 @@ void UARTDecoder::FinishPacket(Packet* pack)
 	m_packets.push_back(pack);
 }
 
-Gdk::Color UARTWaveform::GetColor(size_t /*i*/)
+Gdk::Color ASCIIWaveform::GetColor(size_t /*i*/)
 {
 	return Gdk::Color(m_color);
 }
 
-string UARTWaveform::GetText(size_t i)
+string ASCIIWaveform::GetText(size_t i)
 {
 	char c = m_samples[i];
 	char sbuf[16] = {0};

--- a/scopeprotocols/UARTDecoder.cpp
+++ b/scopeprotocols/UARTDecoder.cpp
@@ -104,7 +104,7 @@ void UARTDecoder::Refresh()
 	int64_t scaledbitper = ibitper / din->m_timescale;
 
 	//UART processing
-	auto cap = new AsciiWaveform;
+	auto cap = new UARTWaveform(m_displaycolor);
 	cap->m_timescale = din->m_timescale;
 	cap->m_startTimestamp = din->m_startTimestamp;
 	cap->m_startFemtoseconds = din->m_startFemtoseconds;
@@ -223,12 +223,24 @@ void UARTDecoder::FinishPacket(Packet* pack)
 	m_packets.push_back(pack);
 }
 
-Gdk::Color UARTDecoder::GetColor(size_t /*i*/, size_t /*stream*/)
+Gdk::Color UARTWaveform::GetColor(size_t /*i*/)
 {
-	return Gdk::Color(m_displaycolor);
+	return Gdk::Color(m_color);
 }
 
-string UARTDecoder::GetText(size_t i, size_t /*stream*/)
+string UARTWaveform::GetText(size_t i)
 {
-	return Filter::GetTextForAsciiChannel(i, 0);
+	char c = m_samples[i];
+	char sbuf[16] = {0};
+	if(isprint(c))
+		sbuf[0] = c;
+	else if(c == '\r')		//special case common non-printable chars
+		return "\\r";
+	else if(c == '\n')
+		return "\\n";
+	else if(c == '\b')
+		return "\\b";
+	else
+		snprintf(sbuf, sizeof(sbuf), "\\x%02x", 0xFF & c);
+	return sbuf;
 }

--- a/scopeprotocols/UARTDecoder.h
+++ b/scopeprotocols/UARTDecoder.h
@@ -38,10 +38,10 @@
 
 #include "../scopehal/PacketDecoder.h"
 
-class ASCIIWaveform : public Waveform<char>
+class ByteWaveform : public Waveform<char>
 {
 public:
-	ASCIIWaveform (const std::string& color) : Waveform<char>(), m_color(color) {};
+	ByteWaveform (const std::string& color) : Waveform<char>(), m_color(color) {};
 	virtual std::string GetText(size_t) override;
 	virtual Gdk::Color GetColor(size_t) override;
 

--- a/scopeprotocols/UARTDecoder.h
+++ b/scopeprotocols/UARTDecoder.h
@@ -38,14 +38,22 @@
 
 #include "../scopehal/PacketDecoder.h"
 
+class UARTWaveform : public Waveform<char>
+{
+public:
+	UARTWaveform (const std::string& color) : Waveform<char>(), m_color(color) {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+
+private:
+	const std::string& m_color;
+};
+
 class UARTDecoder : public PacketDecoder
 {
 public:
 	UARTDecoder(const std::string& color);
 	virtual ~UARTDecoder();
-
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
 
 	virtual void Refresh();
 

--- a/scopeprotocols/UARTDecoder.h
+++ b/scopeprotocols/UARTDecoder.h
@@ -38,10 +38,10 @@
 
 #include "../scopehal/PacketDecoder.h"
 
-class UARTWaveform : public Waveform<char>
+class ASCIIWaveform : public Waveform<char>
 {
 public:
-	UARTWaveform (const std::string& color) : Waveform<char>(), m_color(color) {};
+	ASCIIWaveform (const std::string& color) : Waveform<char>(), m_color(color) {};
 	virtual std::string GetText(size_t) override;
 	virtual Gdk::Color GetColor(size_t) override;
 

--- a/scopeprotocols/USB2PCSDecoder.cpp
+++ b/scopeprotocols/USB2PCSDecoder.cpp
@@ -506,9 +506,9 @@ Gdk::Color USB2PCSDecoder::GetColor(size_t i, size_t /*stream*/)
 {
 	auto data = dynamic_cast<USB2PCSWaveform*>(GetData(0));
 	if(data == NULL)
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 	if(i >= data->m_samples.size())
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 	//TODO: have a set of standard colors we use everywhere?
 
@@ -516,18 +516,18 @@ Gdk::Color USB2PCSDecoder::GetColor(size_t i, size_t /*stream*/)
 	switch(sample.m_type)
 	{
 		case USB2PCSSymbol::TYPE_SYNC:
-			return m_standardColors[COLOR_PREAMBLE];
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 		case USB2PCSSymbol::TYPE_EOP:
-			return m_standardColors[COLOR_PREAMBLE];
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 		case USB2PCSSymbol::TYPE_RESET:
-			return m_standardColors[COLOR_CONTROL];
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
 		case USB2PCSSymbol::TYPE_DATA:
-			return m_standardColors[COLOR_DATA];
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
 		//invalid state, should never happen
 		case USB2PCSSymbol::TYPE_ERROR:
 		default:
-			return m_standardColors[COLOR_ERROR];
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
 }
 

--- a/scopeprotocols/USB2PCSDecoder.cpp
+++ b/scopeprotocols/USB2PCSDecoder.cpp
@@ -502,17 +502,9 @@ void USB2PCSDecoder::RefreshIterationData(
 	}
 }
 
-Gdk::Color USB2PCSDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color USB2PCSWaveform::GetColor(size_t i)
 {
-	auto data = dynamic_cast<USB2PCSWaveform*>(GetData(0));
-	if(data == NULL)
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-	if(i >= data->m_samples.size())
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-
-	//TODO: have a set of standard colors we use everywhere?
-
-	auto sample = data->m_samples[i];
+	auto sample = m_samples[i];
 	switch(sample.m_type)
 	{
 		case USB2PCSSymbol::TYPE_SYNC:
@@ -531,15 +523,9 @@ Gdk::Color USB2PCSDecoder::GetColor(size_t i, size_t /*stream*/)
 	}
 }
 
-string USB2PCSDecoder::GetText(size_t i, size_t /*stream*/)
+string USB2PCSWaveform::GetText(size_t i)
 {
-	auto data = dynamic_cast<USB2PCSWaveform*>(GetData(0));
-	if(data == NULL)
-		return "";
-	if(i >= data->m_samples.size())
-		return "";
-
-	auto sample = data->m_samples[i];
+	auto sample = m_samples[i];
 	switch(sample.m_type)
 	{
 		case USB2PCSSymbol::TYPE_SYNC:

--- a/scopeprotocols/USB2PCSDecoder.h
+++ b/scopeprotocols/USB2PCSDecoder.h
@@ -81,9 +81,6 @@ public:
 
 	static std::string GetProtocolName();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
 
 	PROTOCOL_DECODER_INITPROC(USB2PCSDecoder)

--- a/scopeprotocols/USB2PCSDecoder.h
+++ b/scopeprotocols/USB2PCSDecoder.h
@@ -81,8 +81,8 @@ public:
 
 	static std::string GetProtocolName();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
 

--- a/scopeprotocols/USB2PCSDecoder.h
+++ b/scopeprotocols/USB2PCSDecoder.h
@@ -70,7 +70,13 @@ public:
 	}
 };
 
-typedef Waveform<USB2PCSSymbol> USB2PCSWaveform;
+class USB2PCSWaveform : public Waveform<USB2PCSSymbol>
+{
+public:
+	USB2PCSWaveform () : Waveform<USB2PCSSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class USB2PCSDecoder : public Filter
 {

--- a/scopeprotocols/USB2PMADecoder.cpp
+++ b/scopeprotocols/USB2PMADecoder.cpp
@@ -193,9 +193,9 @@ Gdk::Color USB2PMADecoder::GetColor(size_t i, size_t /*stream*/)
 {
 	auto data = dynamic_cast<USB2PMAWaveform*>(GetData(0));
 	if(data == NULL)
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 	if(i >= data->m_samples.size())
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 	//TODO: have a set of standard colors we use everywhere?
 	auto sample = data->m_samples[i];
@@ -203,15 +203,15 @@ Gdk::Color USB2PMADecoder::GetColor(size_t i, size_t /*stream*/)
 	{
 		case USB2PMASymbol::TYPE_J:
 		case USB2PMASymbol::TYPE_K:
-			return m_standardColors[COLOR_DATA];
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
 		case USB2PMASymbol::TYPE_SE0:
-			return m_standardColors[COLOR_PREAMBLE];
+			return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 		//invalid state, should never happen
 		case USB2PMASymbol::TYPE_SE1:
 		default:
-			return m_standardColors[COLOR_ERROR];
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
 }
 

--- a/scopeprotocols/USB2PMADecoder.cpp
+++ b/scopeprotocols/USB2PMADecoder.cpp
@@ -189,16 +189,9 @@ void USB2PMADecoder::Refresh()
 	cap->m_startFemtoseconds = din_p->m_startFemtoseconds;
 }
 
-Gdk::Color USB2PMADecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color USB2PMAWaveform::GetColor(size_t i)
 {
-	auto data = dynamic_cast<USB2PMAWaveform*>(GetData(0));
-	if(data == NULL)
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-	if(i >= data->m_samples.size())
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-
-	//TODO: have a set of standard colors we use everywhere?
-	auto sample = data->m_samples[i];
+	auto sample = m_samples[i];
 	switch(sample.m_type)
 	{
 		case USB2PMASymbol::TYPE_J:
@@ -215,15 +208,9 @@ Gdk::Color USB2PMADecoder::GetColor(size_t i, size_t /*stream*/)
 	}
 }
 
-string USB2PMADecoder::GetText(size_t i, size_t /*stream*/)
+string USB2PMAWaveform::GetText(size_t i)
 {
-	auto data = dynamic_cast<USB2PMAWaveform*>(GetData(0));
-	if(data == NULL)
-		return "";
-	if(i >= data->m_samples.size())
-		return "";
-
-	auto sample = data->m_samples[i];
+	auto sample = m_samples[i];
 	switch(sample.m_type)
 	{
 		case USB2PMASymbol::TYPE_J:

--- a/scopeprotocols/USB2PMADecoder.h
+++ b/scopeprotocols/USB2PMADecoder.h
@@ -76,9 +76,6 @@ public:
 
 	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	enum Speed
 	{
 		SPEED_LOW,

--- a/scopeprotocols/USB2PMADecoder.h
+++ b/scopeprotocols/USB2PMADecoder.h
@@ -76,8 +76,8 @@ public:
 
 	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	enum Speed
 	{

--- a/scopeprotocols/USB2PMADecoder.h
+++ b/scopeprotocols/USB2PMADecoder.h
@@ -63,7 +63,13 @@ public:
 	}
 };
 
-typedef Waveform<USB2PMASymbol> USB2PMAWaveform;
+class USB2PMAWaveform : public Waveform<USB2PMASymbol>
+{
+public:
+	USB2PMAWaveform () : Waveform<USB2PMASymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class USB2PMADecoder : public Filter
 {

--- a/scopeprotocols/USB2PacketDecoder.cpp
+++ b/scopeprotocols/USB2PacketDecoder.cpp
@@ -815,9 +815,9 @@ Gdk::Color USB2PacketDecoder::GetColor(size_t i, size_t /*stream*/)
 {
 	auto data = dynamic_cast<USB2PacketWaveform*>(GetData(0));
 	if(data == NULL)
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 	if(i >= data->m_samples.size())
-		return m_standardColors[COLOR_ERROR];
+		return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 	auto sample = data->m_samples[i];
 	switch(sample.m_type)
@@ -825,34 +825,34 @@ Gdk::Color USB2PacketDecoder::GetColor(size_t i, size_t /*stream*/)
 		case USB2PacketSymbol::TYPE_PID:
 			if( (sample.m_data == USB2PacketSymbol::PID_RESERVED) ||
 				(sample.m_data == USB2PacketSymbol::PID_STALL) )
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 			else
-				return m_standardColors[COLOR_PREAMBLE];
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 
 		case USB2PacketSymbol::TYPE_ADDR:
-			return m_standardColors[COLOR_ADDRESS];
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 		case USB2PacketSymbol::TYPE_ENDP:
-			return m_standardColors[COLOR_ADDRESS];
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 		case USB2PacketSymbol::TYPE_NFRAME:
-			return m_standardColors[COLOR_DATA];
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
 		case USB2PacketSymbol::TYPE_CRC5_GOOD:
 		case USB2PacketSymbol::TYPE_CRC16_GOOD:
-			return m_standardColors[COLOR_CHECKSUM_OK];
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK];
 
 		case USB2PacketSymbol::TYPE_CRC5_BAD:
 		case USB2PacketSymbol::TYPE_CRC16_BAD:
-			return m_standardColors[COLOR_CHECKSUM_BAD];
+			return StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD];
 
 		case USB2PacketSymbol::TYPE_DATA:
-			return m_standardColors[COLOR_DATA];
+			return StandardColors::colors[StandardColors::COLOR_DATA];
 
 		//invalid state, should never happen
 		case USB2PacketSymbol::TYPE_ERROR:
 		default:
-			return m_standardColors[COLOR_ERROR];
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}
 }
 

--- a/scopeprotocols/USB2PacketDecoder.cpp
+++ b/scopeprotocols/USB2PacketDecoder.cpp
@@ -811,15 +811,9 @@ void USB2PacketDecoder::DecodeData(USB2PacketWaveform* cap, size_t istart, size_
 	m_packets.push_back(pack);
 }
 
-Gdk::Color USB2PacketDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color USB2PacketWaveform::GetColor(size_t i)
 {
-	auto data = dynamic_cast<USB2PacketWaveform*>(GetData(0));
-	if(data == NULL)
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-	if(i >= data->m_samples.size())
-		return StandardColors::colors[StandardColors::COLOR_ERROR];
-
-	auto sample = data->m_samples[i];
+	auto sample = m_samples[i];
 	switch(sample.m_type)
 	{
 		case USB2PacketSymbol::TYPE_PID:
@@ -856,17 +850,11 @@ Gdk::Color USB2PacketDecoder::GetColor(size_t i, size_t /*stream*/)
 	}
 }
 
-string USB2PacketDecoder::GetText(size_t i, size_t /*stream*/)
+string USB2PacketWaveform::GetText(size_t i)
 {
-	auto data = dynamic_cast<USB2PacketWaveform*>(GetData(0));
-	if(data == NULL)
-		return "";
-	if(i >= data->m_samples.size())
-		return "";
-
 	char tmp[32];
 
-	auto sample = data->m_samples[i];
+	auto sample = m_samples[i];
 	switch(sample.m_type)
 	{
 		case USB2PacketSymbol::TYPE_PID:

--- a/scopeprotocols/USB2PacketDecoder.h
+++ b/scopeprotocols/USB2PacketDecoder.h
@@ -104,9 +104,6 @@ public:
 
 	virtual void Refresh();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	static std::string GetProtocolName();
 
 	virtual std::vector<std::string> GetHeaders();

--- a/scopeprotocols/USB2PacketDecoder.h
+++ b/scopeprotocols/USB2PacketDecoder.h
@@ -104,8 +104,8 @@ public:
 
 	virtual void Refresh();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	static std::string GetProtocolName();
 

--- a/scopeprotocols/USB2PacketDecoder.h
+++ b/scopeprotocols/USB2PacketDecoder.h
@@ -95,7 +95,13 @@ public:
 	}
 };
 
-typedef Waveform<USB2PacketSymbol> USB2PacketWaveform;
+class USB2PacketWaveform : public Waveform<USB2PacketSymbol>
+{
+public:
+	USB2PacketWaveform () : Waveform<USB2PacketSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class USB2PacketDecoder : public PacketDecoder
 {

--- a/scopeprotocols/VICPDecoder.cpp
+++ b/scopeprotocols/VICPDecoder.cpp
@@ -252,7 +252,7 @@ void VICPDecoder::Refresh()
 						m_packets.push_back(pack);
 
 						//Save the opcode
-						pack->m_headers["Op"] = GetText(cap->m_samples.size() - 1, 0);
+						pack->m_headers["Op"] = cap->GetText(cap->m_samples.size() - 1);
 
 						//Set color to reflect direction of the packet
 						if(!nextIsTx)
@@ -473,109 +473,98 @@ void VICPDecoder::Refresh()
 	}
 }
 
-Gdk::Color VICPDecoder::GetColor(size_t i, size_t /*stream*/)
+Gdk::Color VICPWaveform::GetColor(size_t i)
 {
-	auto capture = dynamic_cast<VICPWaveform*>(GetData(0));
-	if(capture != NULL)
+	const VICPSymbol& s = m_samples[i];
+
+	switch(s.m_type)
 	{
-		const VICPSymbol& s = capture->m_samples[i];
-
-		switch(s.m_type)
-		{
-			case VICPSymbol::TYPE_RESERVED:
-				if(s.m_data == 0)
-					return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
-				else
-					return StandardColors::colors[StandardColors::COLOR_ERROR];
-
-			case VICPSymbol::TYPE_OPCODE:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
-
-			case VICPSymbol::TYPE_VERSION:
-				if(s.m_data == 1)
-					return StandardColors::colors[StandardColors::COLOR_CONTROL];
-				else
-					return StandardColors::colors[StandardColors::COLOR_ERROR];
-
-			case VICPSymbol::TYPE_SEQ:
-				return StandardColors::colors[StandardColors::COLOR_CONTROL];
-
-			case VICPSymbol::TYPE_LENGTH:
-				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
-
-			case VICPSymbol::TYPE_DATA:
-				return StandardColors::colors[StandardColors::COLOR_DATA];
-
-			default:
+		case VICPSymbol::TYPE_RESERVED:
+			if(s.m_data == 0)
+				return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
+			else
 				return StandardColors::colors[StandardColors::COLOR_ERROR];
-		}
-	}
 
-	return StandardColors::colors[StandardColors::COLOR_ERROR];
+		case VICPSymbol::TYPE_OPCODE:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
+
+		case VICPSymbol::TYPE_VERSION:
+			if(s.m_data == 1)
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
+			else
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
+
+		case VICPSymbol::TYPE_SEQ:
+			return StandardColors::colors[StandardColors::COLOR_CONTROL];
+
+		case VICPSymbol::TYPE_LENGTH:
+			return StandardColors::colors[StandardColors::COLOR_ADDRESS];
+
+		case VICPSymbol::TYPE_DATA:
+			return StandardColors::colors[StandardColors::COLOR_DATA];
+
+		default:
+			return StandardColors::colors[StandardColors::COLOR_ERROR];
+	}
 }
 
-string VICPDecoder::GetText(size_t i, size_t /*stream*/)
+string VICPWaveform::GetText(size_t i)
 {
-	auto capture = dynamic_cast<VICPWaveform*>(GetData(0));
-	if(capture != NULL)
+	const VICPSymbol& s = m_samples[i];
+	char tmp[128];
+
+	switch(s.m_type)
 	{
-		const VICPSymbol& s = capture->m_samples[i];
-		char tmp[128];
+		case VICPSymbol::TYPE_OPCODE:
+			{
+				string ret = "";
+				if(s.m_data & 0x80)
+					ret += "DATA ";
+				if(s.m_data & 0x40)
+					ret += "REMOTE ";
+				if(s.m_data & 0x20)
+					ret += "LOCKOUT ";
+				if(s.m_data & 0x10)
+					ret += "CLEAR ";
+				if(s.m_data & 0x8)
+					ret += "SRQ ";
+				if(s.m_data & 0x4)
+					ret += "REQ ";
+				//0x02 reserved?
+				if(s.m_data & 0x1)
+					ret += "EOI ";
 
-		switch(s.m_type)
-		{
-			case VICPSymbol::TYPE_OPCODE:
-				{
-					string ret = "";
-					if(s.m_data & 0x80)
-						ret += "DATA ";
-					if(s.m_data & 0x40)
-						ret += "REMOTE ";
-					if(s.m_data & 0x20)
-						ret += "LOCKOUT ";
-					if(s.m_data & 0x10)
-						ret += "CLEAR ";
-					if(s.m_data & 0x8)
-						ret += "SRQ ";
-					if(s.m_data & 0x4)
-						ret += "REQ ";
-					//0x02 reserved?
-					if(s.m_data & 0x1)
-						ret += "EOI ";
-
-					return ret;
-				}
-				break;
+				return ret;
+			}
+			break;
 
 
-			case VICPSymbol::TYPE_VERSION:
-				snprintf(tmp, sizeof(tmp), "Version %d", s.m_data);
-				return string(tmp);
+		case VICPSymbol::TYPE_VERSION:
+			snprintf(tmp, sizeof(tmp), "Version %d", s.m_data);
+			return string(tmp);
 
-			case VICPSymbol::TYPE_SEQ:
-				snprintf(tmp, sizeof(tmp), "Seq %d", s.m_data);
-				return string(tmp);
+		case VICPSymbol::TYPE_SEQ:
+			snprintf(tmp, sizeof(tmp), "Seq %d", s.m_data);
+			return string(tmp);
 
-			case VICPSymbol::TYPE_RESERVED:
-				if(s.m_data == 0)
-					return "RESERVED";
-				else
-					return "ERROR";
-
-			case VICPSymbol::TYPE_LENGTH:
-				snprintf(tmp, sizeof(tmp), "Len %d", s.m_data);
-				return string(tmp);
-
-			case VICPSymbol::TYPE_DATA:
-				return s.m_str;
-
-			default:
+		case VICPSymbol::TYPE_RESERVED:
+			if(s.m_data == 0)
+				return "RESERVED";
+			else
 				return "ERROR";
-		}
 
-		return string(tmp);
+		case VICPSymbol::TYPE_LENGTH:
+			snprintf(tmp, sizeof(tmp), "Len %d", s.m_data);
+			return string(tmp);
+
+		case VICPSymbol::TYPE_DATA:
+			return s.m_str;
+
+		default:
+			return "ERROR";
 	}
-	return "";
+
+	return string(tmp);
 }
 
 bool VICPDecoder::CanMerge(Packet* /*first*/, Packet* /*cur*/, Packet* /*next*/)

--- a/scopeprotocols/VICPDecoder.cpp
+++ b/scopeprotocols/VICPDecoder.cpp
@@ -484,34 +484,34 @@ Gdk::Color VICPDecoder::GetColor(size_t i, size_t /*stream*/)
 		{
 			case VICPSymbol::TYPE_RESERVED:
 				if(s.m_data == 0)
-					return m_standardColors[COLOR_PREAMBLE];
+					return StandardColors::colors[StandardColors::COLOR_PREAMBLE];
 				else
-					return m_standardColors[COLOR_ERROR];
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 			case VICPSymbol::TYPE_OPCODE:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case VICPSymbol::TYPE_VERSION:
 				if(s.m_data == 1)
-					return m_standardColors[COLOR_CONTROL];
+					return StandardColors::colors[StandardColors::COLOR_CONTROL];
 				else
-					return m_standardColors[COLOR_ERROR];
+					return StandardColors::colors[StandardColors::COLOR_ERROR];
 
 			case VICPSymbol::TYPE_SEQ:
-				return m_standardColors[COLOR_CONTROL];
+				return StandardColors::colors[StandardColors::COLOR_CONTROL];
 
 			case VICPSymbol::TYPE_LENGTH:
-				return m_standardColors[COLOR_ADDRESS];
+				return StandardColors::colors[StandardColors::COLOR_ADDRESS];
 
 			case VICPSymbol::TYPE_DATA:
-				return m_standardColors[COLOR_DATA];
+				return StandardColors::colors[StandardColors::COLOR_DATA];
 
 			default:
-				return m_standardColors[COLOR_ERROR];
+				return StandardColors::colors[StandardColors::COLOR_ERROR];
 		}
 	}
 
-	return m_standardColors[COLOR_ERROR];
+	return StandardColors::colors[StandardColors::COLOR_ERROR];
 }
 
 string VICPDecoder::GetText(size_t i, size_t /*stream*/)

--- a/scopeprotocols/VICPDecoder.h
+++ b/scopeprotocols/VICPDecoder.h
@@ -73,7 +73,13 @@ public:
 	}
 };
 
-typedef Waveform<VICPSymbol> VICPWaveform;
+class VICPWaveform : public Waveform<VICPSymbol>
+{
+public:
+	VICPWaveform () : Waveform<VICPSymbol>() {};
+	virtual std::string GetText(size_t) override;
+	virtual Gdk::Color GetColor(size_t) override;
+};
 
 class VICPDecoder : public PacketDecoder
 {

--- a/scopeprotocols/VICPDecoder.h
+++ b/scopeprotocols/VICPDecoder.h
@@ -81,8 +81,8 @@ public:
 	VICPDecoder(const std::string& color);
 	virtual ~VICPDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream) override;
-	virtual std::string GetText(size_t i, size_t stream) override;
+	virtual Gdk::Color GetColor(size_t i, size_t stream);
+	virtual std::string GetText(size_t i, size_t stream);
 
 	virtual void Refresh();
 

--- a/scopeprotocols/VICPDecoder.h
+++ b/scopeprotocols/VICPDecoder.h
@@ -81,9 +81,6 @@ public:
 	VICPDecoder(const std::string& color);
 	virtual ~VICPDecoder();
 
-	virtual Gdk::Color GetColor(size_t i, size_t stream);
-	virtual std::string GetText(size_t i, size_t stream);
-
 	virtual void Refresh();
 
 	std::vector<std::string> GetHeaders();


### PR DESCRIPTION
 - Deduplicates IBM8b10b code and allows selecting display format on QSGMII decodes.
 - Moves AsciiWaveform definition into libscopeprotocols as ByteWaveform.