### PR TITLE
Fix scopehal build for WIN32 (Windows mingw64)

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -136,6 +136,39 @@ configure_file(config.h.in config.h)
 
 add_library(scopehal SHARED
 	${SCOPEHAL_SOURCES})
+
+if(WIN32)
+# mingw64 build using 
+# https://sdk.lunarg.com/sdk/download/1.3.224.1/windows/VulkanSDK-1.3.224.1-Installer.exe
+# https://github.com/KhronosGroup/glslang.git (tags/sdk-1.3.224.1) static lib (SPIRV* glslang OGLCompiler GenericCodeGen MachineIndependent OSDependent)
+target_link_libraries(scopehal
+	${SIGCXX_LIBRARIES}
+	${GTKMM_LIBRARIES}
+	xptools
+	log
+	graphwidget
+	${YAML_LIBRARIES}
+	${LXI_LIBRARIES}
+	${LINUXGPIB_LIBRARIES}
+	${WIN_LIBS}
+	${LIN_LIBS}
+	${LIBFFTS_LIBRARIES}
+	${OpenMP_CXX_LIBRARIES}
+	${Vulkan_LIBRARIES}
+	SPIRV
+	SPIRV-Tools-opt
+	SPIRV-Tools
+	glslang
+	Vulkan::Vulkan
+	-Wl,--start-group 
+	OGLCompiler
+	GenericCodeGen
+	MachineIndependent
+	-Wl,--end-group
+	OSDependent
+	glfw
+	)
+else()
 target_link_libraries(scopehal
 	${SIGCXX_LIBRARIES}
 	${GTKMM_LIBRARIES}
@@ -159,6 +192,7 @@ target_link_libraries(scopehal
 	OSDependent
 	glfw
 	)
+endif()
 
 target_include_directories(scopehal
 PUBLIC


### PR DESCRIPTION
Fix scopehal build for WIN32 (Windows mingw64)
To build successfully it is required to install VulkanSDK-1.3.224.1-Installer.exe and build glslang.git tags/sdk-1.3.224.1 with mingw64
- VulkanSDK-1.3.224.1-Installer.exe available on https://vulkan.lunarg.com/sdk/home
- Build glslang.git tags/sdk-1.3.224.1 with mingw64
```
# Windows mingw64 glslang build (as it is not fully integrated in VulkanSDK-1.3.224.1 for Windows and built with Visual Studio 2017)
cd ~
git clone https://github.com/KhronosGroup/glslang.git
cd glslang
git checkout tags/sdk-1.3.224.1
git clone https://github.com/google/googletest.git External/googletest
cd External/googletest
git checkout 0c400f67fcf305869c5fb113dd296eca266c9725
cd ../..
./update_glslang_sources.py

SOURCE_DIR=~/glslang
BUILD_DIR=$SOURCE_DIR/build
mkdir -p $BUILD_DIR
cd $BUILD_DIR
cmake -DCMAKE_BUILD_TYPE=Release -G"MinGW Makefiles" $SOURCE_DIR -DCMAKE_INSTALL_PREFIX="$(pwd)/install"

cmake --build . --config Release --target install
```
Fix https://github.com/glscopeclient/scopehal-apps/issues/470#issuecomment-1242674690