### PR TITLE
macOS Compile Fixes

### DIFF
--- a/scopeexports/CSVExportWizard.cpp
+++ b/scopeexports/CSVExportWizard.cpp
@@ -304,7 +304,7 @@ void CSVExportWizard::on_apply()
 
 	//Write data
 	//TODO: lots of redundant casting, this can probably be optimized!
-	int64_t lastTimestamp = LONG_LONG_MIN;
+	int64_t lastTimestamp = INT64_MIN;
 	auto timebaseSparse = dynamic_cast<SparseWaveformBase*>(timebaseWaveform);
 	auto timebaseUniform = dynamic_cast<UniformWaveformBase*>(timebaseWaveform);
 	auto timebaseSparseAnalog = dynamic_cast<SparseAnalogWaveform*>(timebaseWaveform);

--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -3,6 +3,7 @@ link_directories(${GTKMM_LIBRARY_DIRS} ${SIGCXX_LIBRARY_DIRS})
 
 find_library(LXI_LIB lxi)
 find_library(LINUXGPIB_LIB gpib)
+find_package(glfw3 REQUIRED)
 
 
 # Additional Windows/Linux libraries
@@ -183,13 +184,9 @@ target_link_libraries(scopehal
 	${LIBFFTS_LIBRARIES}
 	${OpenMP_CXX_LIBRARIES}
 	${Vulkan_LIBRARIES}
-	SPIRV
-	glslang
 	Vulkan::Vulkan
-	OGLCompiler
-	GenericCodeGen
-	MachineIndependent
-	OSDependent
+	Vulkan::glslang
+	Vulkan::shaderc_combined
 	glfw
 	)
 endif()
@@ -202,7 +199,9 @@ PUBLIC
 	${YAML_INCLUDES}
 
 	# TODO: this needs to come from FindPackage etc
-	/usr/include/glslang/Include/
+	/usr/include/glslang/Include
+	# for macOS:
+	/usr/local/include/glslang/Include
 	)
 
 target_include_directories(scopehal

--- a/scopehal/RemoteBridgeOscilloscope.cpp
+++ b/scopehal/RemoteBridgeOscilloscope.cpp
@@ -37,7 +37,7 @@ using namespace std;
 
 RemoteBridgeOscilloscope::RemoteBridgeOscilloscope(SCPITransport* transport, bool identify)
 	: SCPIDevice(transport, identify)
-	, SCPIOscilloscope(transport, identify)
+	, SCPIOscilloscope()
 	, m_triggerArmed(false)
 {
 

--- a/scopehal/VulkanInit.cpp
+++ b/scopehal/VulkanInit.cpp
@@ -288,7 +288,7 @@ bool VulkanInit(bool skipGLFW)
 
 		//Required for MoltenVK
 		#ifdef __APPLE__
-		extensionsToUse.push(back("VK_KHR_portability_enumeration");
+		extensionsToUse.push_back("VK_KHR_portability_enumeration");
 		#endif
 
 		//See what extensions are required
@@ -311,7 +311,7 @@ bool VulkanInit(bool skipGLFW)
 		}
 
 		//Create the instance
-		vk::InstanceCreateInfo instanceInfo({}, &appInfo, {}, extensionsToUse);
+		vk::InstanceCreateInfo instanceInfo(vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR, &appInfo, {}, extensionsToUse);
 		g_vkInstance = make_unique<vk::raii::Instance>(g_vkContext, instanceInfo);
 
 		//Look at our physical devices and print info out for each one

--- a/scopehal/VulkanInit.cpp
+++ b/scopehal/VulkanInit.cpp
@@ -263,7 +263,6 @@ bool VulkanInit(bool skipGLFW)
 			//Initialize glfw
 			glfwInitHint(GLFW_JOYSTICK_HAT_BUTTONS, GLFW_FALSE);
 			glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
-			glfwInitHint(GLFW_COCOA_MENUBAR, GLFW_FALSE);
 			if(!glfwInit())
 			{
 				LogError("glfw init failed\n");

--- a/scopehal/VulkanInit.cpp
+++ b/scopehal/VulkanInit.cpp
@@ -164,6 +164,9 @@ vk::raii::PhysicalDevice* g_vkfftPhysicalDevice;
  */
 int AllocateVulkanComputeQueue()
 {
+#ifdef __APPLE__
+	return 0;
+#endif
 	static mutex allocMutex;
 
 	lock_guard<mutex> lock(allocMutex);
@@ -177,6 +180,9 @@ int AllocateVulkanComputeQueue()
  */
 int AllocateVulkanRenderQueue()
 {
+#ifdef __APPLE__
+	return 0;
+#endif
 	//If compute and rendering use the same kind of queue, make sure we don't double count!
 	if(g_computeQueueType == g_renderQueueType)
 		return AllocateVulkanComputeQueue();


### PR DESCRIPTION
These changes are sufficient to get scopehal compiling and working on my M1 Max MacBook Pro using clang-14 from homebrew.

The reworked Vulkan library includes _should_ be fine across multiple platforms when combined with a small change to the `scopehal-apps` CMakeList.txt that I'll be including in a separate PR in that repository:
```
diff --git a/CMakeLists.txt b/CMakeLists.txt
--- a/CMakeLists.txt
+++ b/CMakeLists.txt

@@ -55,6 +55,7 @@ include(FindOpenMP)
 find_package(glfw3 3.2 REQUIRED)
 
 # Use the local FindVulkan script until we can rely on all users having CMake 3.24 available, at which point we can remove it
+set(Vulkan_FIND_COMPONENTS glslang shaderc_combined)
 include(FindVulkan)
 
 if(NOT Vulkan_FOUND)
 ```
 
 I'm happy to find other means of making the macOS CMake setup happy if this causes issues on other platforms, though.