### PR TITLE
Add basic support for GW Instek GPD-(X)303S power supplies

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -102,6 +102,7 @@ set(SCOPEHAL_SOURCES
 	DemoOscilloscope.cpp
 	DigilentOscilloscope.cpp
 	DSLabsOscilloscope.cpp
+	GWInstekGPDX303SPowerSupply.cpp
 	KeysightDCA.cpp
 	LeCroyOscilloscope.cpp
 	MockOscilloscope.cpp

--- a/scopehal/GWInstekGPDX303SPowerSupply.cpp
+++ b/scopehal/GWInstekGPDX303SPowerSupply.cpp
@@ -199,7 +199,12 @@ void GWInstekGPDX303SPowerSupply::SetPowerVoltage(int chan, double volts)
 	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
 
 	char cmd[128];
-	snprintf(cmd, sizeof(cmd), "VSET%u:%.3f", chan+1, volts);
+	if(!m_model.empty() && m_model.back() == 'D') {
+		// The GPD-3303D only claims to support 100mV voltage granularity
+		snprintf(cmd, sizeof(cmd), "VSET%u:%.1f", chan+1, volts);
+	} else {
+		snprintf(cmd, sizeof(cmd), "VSET%u:%.3f", chan+1, volts);
+	}
 	m_transport->SendCommandQueued(cmd);
 }
 
@@ -208,7 +213,12 @@ void GWInstekGPDX303SPowerSupply::SetPowerCurrent(int chan, double amps)
 	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
 
 	char cmd[128];
-	snprintf(cmd, sizeof(cmd), "ISET%u:%.3f", chan+1, amps);
+	if(!m_model.empty() && m_model.back() == 'D') {
+		// The GPD-3303D only claims to support 10mA current granularity
+		snprintf(cmd, sizeof(cmd), "ISET%u:%.2f", chan+1, amps);
+	} else {
+		snprintf(cmd, sizeof(cmd), "ISET%u:%.3f", chan+1, amps);
+	}
 	m_transport->SendCommandQueued(cmd);
 }
 

--- a/scopehal/GWInstekGPDX303SPowerSupply.cpp
+++ b/scopehal/GWInstekGPDX303SPowerSupply.cpp
@@ -54,6 +54,29 @@ unsigned int GWInstekGPDX303SPowerSupply::GetInstrumentTypes()
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device capabilities
+
+bool GWInstekGPDX303SPowerSupply::SupportsSoftStart()
+{
+	return false;
+}
+
+bool GWInstekGPDX303SPowerSupply::SupportsIndividualOutputSwitching()
+{
+	return false;
+}
+
+bool GWInstekGPDX303SPowerSupply::SupportsMasterOutputSwitching()
+{
+	return true;
+}
+
+bool GWInstekGPDX303SPowerSupply::SupportsOvercurrentShutdown()
+{
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Actual hardware interfacing
 
 bool GWInstekGPDX303SPowerSupply::IsPowerConstantCurrent(int chan)

--- a/scopehal/GWInstekGPDX303SPowerSupply.cpp
+++ b/scopehal/GWInstekGPDX303SPowerSupply.cpp
@@ -1,0 +1,213 @@
+#include "scopehal.h"
+#include "GWInstekGPDX303SPowerSupply.h"
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+GWInstekGPDX303SPowerSupply::GWInstekGPDX303SPowerSupply(SCPITransport* transport)
+	: SCPIDevice(transport)
+	, SCPIInstrument(transport)
+{
+    auto modelNumber = atoi(m_model.c_str() + strlen("GPD-"));
+	// The GPD-3303S/D models have three channels, but only two are programmable and visible via SCPI
+    if (modelNumber == 3303) {
+        m_channelCount = 2;
+    } else {
+        m_channelCount = modelNumber/1000;
+    }
+}
+
+GWInstekGPDX303SPowerSupply::~GWInstekGPDX303SPowerSupply()
+{
+
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device info
+
+string GWInstekGPDX303SPowerSupply::GetDriverNameInternal()
+{
+	return "gwinstek_gpdx303s";
+}
+
+
+string GWInstekGPDX303SPowerSupply::GetName()
+{
+	return m_model;
+}
+
+string GWInstekGPDX303SPowerSupply::GetVendor()
+{
+	return m_vendor;
+}
+
+string GWInstekGPDX303SPowerSupply::GetSerial()
+{
+	return m_serial;
+}
+
+unsigned int GWInstekGPDX303SPowerSupply::GetInstrumentTypes()
+{
+	return INST_PSU;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Actual hardware interfacing
+
+bool GWInstekGPDX303SPowerSupply::IsPowerConstantCurrent(int chan)
+{
+	int reg = GetStatusRegister();
+    if (chan >= 2) {
+        // TODO - examine a real-world output of the `STATUS?` command on a GPD-4303S, STATUS? is only documented for two channels in the user manual.
+        LogError("Error: CC/CV status encoding unknown for 3/4 channel scopes.\n");
+    }
+	return !(reg & (1 << chan));
+}
+
+uint8_t GWInstekGPDX303SPowerSupply::GetStatusRegister()
+{
+	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+
+	//Get status register
+	auto ret = m_transport->SendCommandQueuedWithReply("STATUS?");
+    // 8 bits in the following format:
+    // Bit    Item     Description
+    // 0      CH1      0=CC mode, 1=CV mode
+    // 1      CH2      0=CC mode, 1=CV mode
+    // 2, 3   Tracking 01=Independent, 11=Tracking series, 10=Tracking parallel
+    // 4      Beep     0=Off, 1=On
+    // 5      Output   0=Off, 1=On
+    // 6, 7   Baud     00=115200bps, 01=57600bps, 10=9600bps
+	return atoi(ret.c_str());
+}
+
+int GWInstekGPDX303SPowerSupply::GetPowerChannelCount()
+{
+	return m_channelCount;
+}
+
+string GWInstekGPDX303SPowerSupply::GetPowerChannelName(int chan)
+{
+	char tmp[] = "CH1";
+	tmp[2] += chan;
+	return string(tmp);
+}
+
+double GWInstekGPDX303SPowerSupply::GetPowerVoltageActual(int chan)
+{
+	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+
+    char tmpCmd[] = "VOUT1?";
+    tmpCmd[4] += chan;
+	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
+	return atof(ret.c_str());
+}
+
+double GWInstekGPDX303SPowerSupply::GetPowerVoltageNominal(int chan)
+{
+	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+
+    char tmpCmd[] = "VSET1?";
+    tmpCmd[4] += chan;
+	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
+	return atof(ret.c_str());
+}
+
+double GWInstekGPDX303SPowerSupply::GetPowerCurrentActual(int chan)
+{
+	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+
+    char tmpCmd[] = "IOUT1?";
+    tmpCmd[4] += chan;
+	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
+	return atof(ret.c_str());
+}
+
+double GWInstekGPDX303SPowerSupply::GetPowerCurrentNominal(int chan)
+{
+	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+
+    char tmpCmd[] = "ISET1?";
+    tmpCmd[4] += chan;
+	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
+	return atof(ret.c_str());
+}
+
+bool GWInstekGPDX303SPowerSupply::GetPowerChannelActive(int chan)
+{
+    (void) chan;
+    return true;
+}
+
+bool GWInstekGPDX303SPowerSupply::IsSoftStartEnabled(int chan)
+{
+    (void) chan;
+    return false;
+}
+
+void GWInstekGPDX303SPowerSupply::SetSoftStartEnabled(int chan, bool enable)
+{
+    (void) chan;
+    (void) enable;
+}
+
+void GWInstekGPDX303SPowerSupply::SetPowerOvercurrentShutdownEnabled(int chan, bool enable)
+{
+    (void) chan;
+    (void) enable;
+}
+
+bool GWInstekGPDX303SPowerSupply::GetPowerOvercurrentShutdownEnabled(int chan)
+{
+    (void) chan;
+    return false;
+}
+
+bool GWInstekGPDX303SPowerSupply::GetPowerOvercurrentShutdownTripped(int chan)
+{
+    (void) chan;
+    return false;
+}
+
+void GWInstekGPDX303SPowerSupply::SetPowerVoltage(int chan, double volts)
+{
+	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+
+	char cmd[128];
+	snprintf(cmd, sizeof(cmd), "VSET%u:%.3f", chan, volts);
+	m_transport->SendCommandQueued(cmd);
+}
+
+void GWInstekGPDX303SPowerSupply::SetPowerCurrent(int chan, double amps)
+{
+	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+
+	char cmd[128];
+	snprintf(cmd, sizeof(cmd), "ISET%u:%.3f", chan, amps);
+	m_transport->SendCommandQueued(cmd);
+}
+
+void GWInstekGPDX303SPowerSupply::SetPowerChannelActive(int chan, bool on)
+{
+    (void) chan;
+    (void) on;
+}
+
+bool GWInstekGPDX303SPowerSupply::GetMasterPowerEnable()
+{
+	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+
+	int reg = GetStatusRegister();
+	return (reg & (1 << 5));
+}
+
+void GWInstekGPDX303SPowerSupply::SetMasterPowerEnable(bool enable)
+{
+	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+    if (enable)
+        m_transport->SendCommandQueued("OUT1");
+    else
+        m_transport->SendCommandQueued("OUT0");
+}

--- a/scopehal/GWInstekGPDX303SPowerSupply.cpp
+++ b/scopehal/GWInstekGPDX303SPowerSupply.cpp
@@ -10,13 +10,13 @@ GWInstekGPDX303SPowerSupply::GWInstekGPDX303SPowerSupply(SCPITransport* transpor
 	: SCPIDevice(transport)
 	, SCPIInstrument(transport)
 {
-    auto modelNumber = atoi(m_model.c_str() + strlen("GPD-"));
+	auto modelNumber = atoi(m_model.c_str() + strlen("GPD-"));
 	// The GPD-3303S/D models have three channels, but only two are programmable and visible via SCPI
-    if (modelNumber == 3303) {
-        m_channelCount = 2;
-    } else {
-        m_channelCount = modelNumber/1000;
-    }
+	if (modelNumber == 3303) {
+		m_channelCount = 2;
+	} else {
+		m_channelCount = modelNumber/1000;
+	}
 }
 
 GWInstekGPDX303SPowerSupply::~GWInstekGPDX303SPowerSupply()
@@ -73,7 +73,7 @@ bool GWInstekGPDX303SPowerSupply::SupportsMasterOutputSwitching()
 
 bool GWInstekGPDX303SPowerSupply::SupportsOvercurrentShutdown()
 {
-    return false;
+	return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -82,10 +82,10 @@ bool GWInstekGPDX303SPowerSupply::SupportsOvercurrentShutdown()
 bool GWInstekGPDX303SPowerSupply::IsPowerConstantCurrent(int chan)
 {
 	int reg = GetStatusRegister();
-    if (chan >= 2) {
-        // TODO - examine a real-world output of the `STATUS?` command on a GPD-4303S, STATUS? is only documented for two channels in the user manual.
-        LogError("Error: CC/CV status encoding unknown for 3/4 channel scopes.\n");
-    }
+	if (chan >= 2) {
+		// TODO - examine a real-world output of the `STATUS?` command on a GPD-4303S, STATUS? is only documented for two channels in the user manual.
+		LogError("Error: CC/CV status encoding unknown for 3/4 channel scopes.\n");
+	}
 	return (reg & (1 << (7 - chan)));
 }
 
@@ -95,14 +95,14 @@ uint8_t GWInstekGPDX303SPowerSupply::GetStatusRegister()
 
 	//Get status register
 	auto ret = m_transport->SendCommandQueuedWithReply("STATUS?");
-    // 8 bits in the following format, 0 being most-significant bit:
-    // Bit    Item     Description
-    // 0      CH1      1=CC mode, 0=CV mode (note: manual specifies CC/CV statuses backwards)
-    // 1      CH2      1=CC mode, 0=CV mode (note: manual specifies CC/CV statuses backwards)
-    // 2, 3   Tracking 01=Independent, 11=Tracking series, 10=Tracking parallel
-    // 4      Beep     0=Off, 1=On
-    // 5      Output   0=Off, 1=On
-    // 6, 7   Baud     00=115200bps, 01=57600bps, 10=9600bps
+	// 8 bits in the following format, 0 being most-significant bit:
+	// Bit    Item     Description
+	// 0      CH1      1=CC mode, 0=CV mode (note: manual specifies CC/CV statuses backwards)
+	// 1      CH2      1=CC mode, 0=CV mode (note: manual specifies CC/CV statuses backwards)
+	// 2, 3   Tracking 01=Independent, 11=Tracking series, 10=Tracking parallel
+	// 4      Beep     0=Off, 1=On
+	// 5      Output   0=Off, 1=On
+	// 6, 7   Baud     00=115200bps, 01=57600bps, 10=9600bps
 	return atoi(ret.c_str());
 }
 
@@ -122,8 +122,8 @@ double GWInstekGPDX303SPowerSupply::GetPowerVoltageActual(int chan)
 {
 	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
 
-    char tmpCmd[] = "VOUT1?";
-    tmpCmd[4] += chan;
+	char tmpCmd[] = "VOUT1?";
+	tmpCmd[4] += chan;
 	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
 	return atof(ret.c_str());
 }
@@ -132,8 +132,8 @@ double GWInstekGPDX303SPowerSupply::GetPowerVoltageNominal(int chan)
 {
 	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
 
-    char tmpCmd[] = "VSET1?";
-    tmpCmd[4] += chan;
+	char tmpCmd[] = "VSET1?";
+	tmpCmd[4] += chan;
 	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
 	return atof(ret.c_str());
 }
@@ -142,8 +142,8 @@ double GWInstekGPDX303SPowerSupply::GetPowerCurrentActual(int chan)
 {
 	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
 
-    char tmpCmd[] = "IOUT1?";
-    tmpCmd[4] += chan;
+	char tmpCmd[] = "IOUT1?";
+	tmpCmd[4] += chan;
 	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
 	return atof(ret.c_str());
 }
@@ -152,46 +152,46 @@ double GWInstekGPDX303SPowerSupply::GetPowerCurrentNominal(int chan)
 {
 	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
 
-    char tmpCmd[] = "ISET1?";
-    tmpCmd[4] += chan;
+	char tmpCmd[] = "ISET1?";
+	tmpCmd[4] += chan;
 	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
 	return atof(ret.c_str());
 }
 
 bool GWInstekGPDX303SPowerSupply::GetPowerChannelActive(int chan)
 {
-    (void) chan;
-    return true;
+	(void) chan;
+	return true;
 }
 
 bool GWInstekGPDX303SPowerSupply::IsSoftStartEnabled(int chan)
 {
-    (void) chan;
-    return false;
+	(void) chan;
+	return false;
 }
 
 void GWInstekGPDX303SPowerSupply::SetSoftStartEnabled(int chan, bool enable)
 {
-    (void) chan;
-    (void) enable;
+	(void) chan;
+	(void) enable;
 }
 
 void GWInstekGPDX303SPowerSupply::SetPowerOvercurrentShutdownEnabled(int chan, bool enable)
 {
-    (void) chan;
-    (void) enable;
+	(void) chan;
+	(void) enable;
 }
 
 bool GWInstekGPDX303SPowerSupply::GetPowerOvercurrentShutdownEnabled(int chan)
 {
-    (void) chan;
-    return false;
+	(void) chan;
+	return false;
 }
 
 bool GWInstekGPDX303SPowerSupply::GetPowerOvercurrentShutdownTripped(int chan)
 {
-    (void) chan;
-    return false;
+	(void) chan;
+	return false;
 }
 
 void GWInstekGPDX303SPowerSupply::SetPowerVoltage(int chan, double volts)
@@ -214,8 +214,8 @@ void GWInstekGPDX303SPowerSupply::SetPowerCurrent(int chan, double amps)
 
 void GWInstekGPDX303SPowerSupply::SetPowerChannelActive(int chan, bool on)
 {
-    (void) chan;
-    (void) on;
+	(void) chan;
+	(void) on;
 }
 
 bool GWInstekGPDX303SPowerSupply::GetMasterPowerEnable()
@@ -229,8 +229,8 @@ bool GWInstekGPDX303SPowerSupply::GetMasterPowerEnable()
 void GWInstekGPDX303SPowerSupply::SetMasterPowerEnable(bool enable)
 {
 	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
-    if (enable)
-        m_transport->SendCommandQueued("OUT1");
-    else
-        m_transport->SendCommandQueued("OUT0");
+	if (enable)
+		m_transport->SendCommandQueued("OUT1");
+	else
+		m_transport->SendCommandQueued("OUT0");
 }

--- a/scopehal/GWInstekGPDX303SPowerSupply.cpp
+++ b/scopehal/GWInstekGPDX303SPowerSupply.cpp
@@ -13,11 +13,10 @@ GWInstekGPDX303SPowerSupply::GWInstekGPDX303SPowerSupply(SCPITransport* transpor
 {
 	auto modelNumber = atoi(m_model.c_str() + strlen("GPD-"));
 	// The GPD-3303S/D models have three channels, but only two are programmable and visible via SCPI
-	if (modelNumber == 3303) {
+	if (modelNumber == 3303)
 		m_channelCount = 2;
-	} else {
+	else
 		m_channelCount = modelNumber/1000;
-	}
 }
 
 GWInstekGPDX303SPowerSupply::~GWInstekGPDX303SPowerSupply()
@@ -49,32 +48,12 @@ string GWInstekGPDX303SPowerSupply::GetSerial()
 	return m_serial;
 }
 
-unsigned int GWInstekGPDX303SPowerSupply::GetInstrumentTypes()
-{
-	return INST_PSU;
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Device capabilities
-
-bool GWInstekGPDX303SPowerSupply::SupportsSoftStart()
-{
-	return false;
-}
-
-bool GWInstekGPDX303SPowerSupply::SupportsIndividualOutputSwitching()
-{
-	return false;
-}
 
 bool GWInstekGPDX303SPowerSupply::SupportsMasterOutputSwitching()
 {
 	return true;
-}
-
-bool GWInstekGPDX303SPowerSupply::SupportsOvercurrentShutdown()
-{
-	return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -83,17 +62,14 @@ bool GWInstekGPDX303SPowerSupply::SupportsOvercurrentShutdown()
 bool GWInstekGPDX303SPowerSupply::IsPowerConstantCurrent(int chan)
 {
 	auto reg = GetStatusRegister();
-	if (chan >= 2) {
+	if(chan >= 2)
 		// TODO - examine a real-world output of the `STATUS?` command on a GPD-4303S, STATUS? is only documented for two channels in the user manual.
-		LogError("Error: CC/CV status encoding unknown for 3/4 channel scopes.\n");
-	}
+		LogError("Error: CC/CV status encoding unknown for 3/4 channel supplies.\n");
 	return !reg[7 - chan];
 }
 
 bitset<8> GWInstekGPDX303SPowerSupply::GetStatusRegister()
 {
-	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
-
 	//Get status register
 	auto ret = m_transport->SendCommandQueuedWithReply("STATUS?");
 	// 8 ASCII 0/1 characters representing bits in the following format, index 0 being most-significant bit:
@@ -123,8 +99,6 @@ string GWInstekGPDX303SPowerSupply::GetPowerChannelName(int chan)
 
 double GWInstekGPDX303SPowerSupply::GetPowerVoltageActual(int chan)
 {
-	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
-
 	char tmpCmd[] = "VOUT1?";
 	tmpCmd[4] += chan;
 	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
@@ -133,8 +107,6 @@ double GWInstekGPDX303SPowerSupply::GetPowerVoltageActual(int chan)
 
 double GWInstekGPDX303SPowerSupply::GetPowerVoltageNominal(int chan)
 {
-	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
-
 	char tmpCmd[] = "VSET1?";
 	tmpCmd[4] += chan;
 	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
@@ -143,8 +115,6 @@ double GWInstekGPDX303SPowerSupply::GetPowerVoltageNominal(int chan)
 
 double GWInstekGPDX303SPowerSupply::GetPowerCurrentActual(int chan)
 {
-	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
-
 	char tmpCmd[] = "IOUT1?";
 	tmpCmd[4] += chan;
 	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
@@ -153,95 +123,42 @@ double GWInstekGPDX303SPowerSupply::GetPowerCurrentActual(int chan)
 
 double GWInstekGPDX303SPowerSupply::GetPowerCurrentNominal(int chan)
 {
-	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
-
 	char tmpCmd[] = "ISET1?";
 	tmpCmd[4] += chan;
 	auto ret = m_transport->SendCommandQueuedWithReply(string(tmpCmd));
 	return atof(ret.c_str());
 }
 
-bool GWInstekGPDX303SPowerSupply::GetPowerChannelActive(int chan)
-{
-	(void) chan;
-	return true;
-}
-
-bool GWInstekGPDX303SPowerSupply::IsSoftStartEnabled(int chan)
-{
-	(void) chan;
-	return false;
-}
-
-void GWInstekGPDX303SPowerSupply::SetSoftStartEnabled(int chan, bool enable)
-{
-	(void) chan;
-	(void) enable;
-}
-
-void GWInstekGPDX303SPowerSupply::SetPowerOvercurrentShutdownEnabled(int chan, bool enable)
-{
-	(void) chan;
-	(void) enable;
-}
-
-bool GWInstekGPDX303SPowerSupply::GetPowerOvercurrentShutdownEnabled(int chan)
-{
-	(void) chan;
-	return false;
-}
-
-bool GWInstekGPDX303SPowerSupply::GetPowerOvercurrentShutdownTripped(int chan)
-{
-	(void) chan;
-	return false;
-}
-
 void GWInstekGPDX303SPowerSupply::SetPowerVoltage(int chan, double volts)
 {
-	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
-
 	char cmd[128];
-	if(!m_model.empty() && m_model.back() == 'D') {
+	if(!m_model.empty() && m_model.back() == 'D')
 		// The GPD-3303D only claims to support 100mV voltage granularity
 		snprintf(cmd, sizeof(cmd), "VSET%u:%.1f", chan+1, volts);
-	} else {
+	else
 		snprintf(cmd, sizeof(cmd), "VSET%u:%.3f", chan+1, volts);
-	}
 	m_transport->SendCommandQueued(cmd);
 }
 
 void GWInstekGPDX303SPowerSupply::SetPowerCurrent(int chan, double amps)
 {
-	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
-
 	char cmd[128];
-	if(!m_model.empty() && m_model.back() == 'D') {
+	if(!m_model.empty() && m_model.back() == 'D')
 		// The GPD-3303D only claims to support 10mA current granularity
 		snprintf(cmd, sizeof(cmd), "ISET%u:%.2f", chan+1, amps);
-	} else {
+	else
 		snprintf(cmd, sizeof(cmd), "ISET%u:%.3f", chan+1, amps);
-	}
 	m_transport->SendCommandQueued(cmd);
-}
-
-void GWInstekGPDX303SPowerSupply::SetPowerChannelActive(int chan, bool on)
-{
-	(void) chan;
-	(void) on;
 }
 
 bool GWInstekGPDX303SPowerSupply::GetMasterPowerEnable()
 {
-	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
-
 	auto reg = GetStatusRegister();
 	return reg[7-5];
 }
 
 void GWInstekGPDX303SPowerSupply::SetMasterPowerEnable(bool enable)
 {
-	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
 	if (enable)
 		m_transport->SendCommandQueued("OUT1");
 	else

--- a/scopehal/GWInstekGPDX303SPowerSupply.h
+++ b/scopehal/GWInstekGPDX303SPowerSupply.h
@@ -53,6 +53,12 @@ class GWInstekGPDX303SPowerSupply
 
 	virtual unsigned int GetInstrumentTypes();
 
+    //Device capabilities
+	virtual bool SupportsSoftStart();
+	virtual bool SupportsIndividualOutputSwitching();
+	virtual bool SupportsMasterOutputSwitching();
+	virtual bool SupportsOvercurrentShutdown();
+
 	//Channel info
 	virtual int GetPowerChannelCount();
 	virtual std::string GetPowerChannelName(int chan);

--- a/scopehal/GWInstekGPDX303SPowerSupply.h
+++ b/scopehal/GWInstekGPDX303SPowerSupply.h
@@ -43,7 +43,7 @@ class GWInstekGPDX303SPowerSupply
 	: public virtual SCPIPowerSupply
 	, public virtual SCPIDevice
 {
-    GWInstekGPDX303SPowerSupply(SCPITransport* transport);
+	GWInstekGPDX303SPowerSupply(SCPITransport* transport);
 	virtual ~GWInstekGPDX303SPowerSupply();
 
 	//Device information
@@ -53,7 +53,7 @@ class GWInstekGPDX303SPowerSupply
 
 	virtual unsigned int GetInstrumentTypes();
 
-    //Device capabilities
+	//Device capabilities
 	virtual bool SupportsSoftStart();
 	virtual bool SupportsIndividualOutputSwitching();
 	virtual bool SupportsMasterOutputSwitching();

--- a/scopehal/GWInstekGPDX303SPowerSupply.h
+++ b/scopehal/GWInstekGPDX303SPowerSupply.h
@@ -1,0 +1,93 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2022 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+#ifndef GWInstekGPDX303SPowerSupply_h
+#define GWInstekGPDX303SPowerSupply_h
+
+#include "SCPIDevice.h"
+#include "SCPIPowerSupply.h"
+#include "SCPITransport.h"
+
+#include <string>
+
+/**
+	@brief A GW Instek GPD-(X)303S power supply
+ */
+class GWInstekGPDX303SPowerSupply
+	: public virtual SCPIPowerSupply
+	, public virtual SCPIDevice
+{
+    GWInstekGPDX303SPowerSupply(SCPITransport* transport);
+	virtual ~GWInstekGPDX303SPowerSupply();
+
+	//Device information
+	virtual std::string GetName();
+	virtual std::string GetVendor();
+	virtual std::string GetSerial();
+
+	virtual unsigned int GetInstrumentTypes();
+
+	//Channel info
+	virtual int GetPowerChannelCount();
+	virtual std::string GetPowerChannelName(int chan);
+
+	//Read sensors
+	virtual double GetPowerVoltageActual(int chan);				//actual voltage after current limiting
+	virtual double GetPowerVoltageNominal(int chan);			//set point
+	virtual double GetPowerCurrentActual(int chan);				//actual current drawn by the load
+	virtual double GetPowerCurrentNominal(int chan);			//current limit
+	virtual bool GetPowerChannelActive(int chan);
+
+	//Configuration
+	virtual bool GetPowerOvercurrentShutdownEnabled(int chan);	//shut channel off entirely on overload,
+																//rather than current limiting
+	virtual void SetPowerOvercurrentShutdownEnabled(int chan, bool enable);
+	virtual bool GetPowerOvercurrentShutdownTripped(int chan);
+	virtual void SetPowerVoltage(int chan, double volts);
+	virtual void SetPowerCurrent(int chan, double amps);
+	virtual void SetPowerChannelActive(int chan, bool on);
+	virtual bool IsPowerConstantCurrent(int chan);
+
+	virtual bool GetMasterPowerEnable();
+	virtual void SetMasterPowerEnable(bool enable);
+
+	virtual bool IsSoftStartEnabled(int chan);
+	virtual void SetSoftStartEnabled(int chan, bool enable);
+
+protected:
+	uint8_t GetStatusRegister();
+
+	int m_channelCount;
+
+public:
+	static std::string GetDriverNameInternal();
+	POWER_INITPROC(GWInstekGPDX303SPowerSupply)
+};
+
+#endif

--- a/scopehal/GWInstekGPDX303SPowerSupply.h
+++ b/scopehal/GWInstekGPDX303SPowerSupply.h
@@ -34,6 +34,7 @@
 #include "SCPIPowerSupply.h"
 #include "SCPITransport.h"
 
+#include <bitset>
 #include <string>
 
 /**
@@ -87,7 +88,7 @@ class GWInstekGPDX303SPowerSupply
 	virtual void SetSoftStartEnabled(int chan, bool enable);
 
 protected:
-	uint8_t GetStatusRegister();
+	std::bitset<8> GetStatusRegister();
 
 	int m_channelCount;
 

--- a/scopehal/GWInstekGPDX303SPowerSupply.h
+++ b/scopehal/GWInstekGPDX303SPowerSupply.h
@@ -48,44 +48,30 @@ class GWInstekGPDX303SPowerSupply
 	virtual ~GWInstekGPDX303SPowerSupply();
 
 	//Device information
-	virtual std::string GetName();
-	virtual std::string GetVendor();
-	virtual std::string GetSerial();
-
-	virtual unsigned int GetInstrumentTypes();
+	std::string GetName() override;
+	std::string GetVendor() override;
+	std::string GetSerial() override;
 
 	//Device capabilities
-	virtual bool SupportsSoftStart();
-	virtual bool SupportsIndividualOutputSwitching();
-	virtual bool SupportsMasterOutputSwitching();
-	virtual bool SupportsOvercurrentShutdown();
+	bool SupportsMasterOutputSwitching() override;
 
 	//Channel info
-	virtual int GetPowerChannelCount();
-	virtual std::string GetPowerChannelName(int chan);
+	int GetPowerChannelCount() override;
+	std::string GetPowerChannelName(int chan) override;
 
 	//Read sensors
-	virtual double GetPowerVoltageActual(int chan);				//actual voltage after current limiting
-	virtual double GetPowerVoltageNominal(int chan);			//set point
-	virtual double GetPowerCurrentActual(int chan);				//actual current drawn by the load
-	virtual double GetPowerCurrentNominal(int chan);			//current limit
-	virtual bool GetPowerChannelActive(int chan);
+	double GetPowerVoltageActual(int chan) override;	//actual voltage after current limiting
+	double GetPowerVoltageNominal(int chan) override;	//set point
+	double GetPowerCurrentActual(int chan) override;	//actual current drawn by the load
+	double GetPowerCurrentNominal(int chan) override;	//current limit
 
 	//Configuration
-	virtual bool GetPowerOvercurrentShutdownEnabled(int chan);	//shut channel off entirely on overload,
-																//rather than current limiting
-	virtual void SetPowerOvercurrentShutdownEnabled(int chan, bool enable);
-	virtual bool GetPowerOvercurrentShutdownTripped(int chan);
-	virtual void SetPowerVoltage(int chan, double volts);
-	virtual void SetPowerCurrent(int chan, double amps);
-	virtual void SetPowerChannelActive(int chan, bool on);
-	virtual bool IsPowerConstantCurrent(int chan);
+	void SetPowerVoltage(int chan, double volts) override;
+	void SetPowerCurrent(int chan, double amps) override;
+	bool IsPowerConstantCurrent(int chan) override;
 
-	virtual bool GetMasterPowerEnable();
-	virtual void SetMasterPowerEnable(bool enable);
-
-	virtual bool IsSoftStartEnabled(int chan);
-	virtual void SetSoftStartEnabled(int chan, bool enable);
+	bool GetMasterPowerEnable() override;
+	void SetMasterPowerEnable(bool enable) override;
 
 protected:
 	std::bitset<8> GetStatusRegister();

--- a/scopehal/PowerSupply.cpp
+++ b/scopehal/PowerSupply.cpp
@@ -37,3 +37,72 @@ PowerSupply::PowerSupply()
 PowerSupply::~PowerSupply()
 {
 }
+
+
+unsigned int PowerSupply::GetInstrumentTypes()
+{
+	return INST_PSU;
+}
+
+bool PowerSupply::SupportsSoftStart()
+{
+	return false;
+}
+
+bool PowerSupply::SupportsIndividualOutputSwitching()
+{
+	return false;
+}
+
+bool PowerSupply::SupportsMasterOutputSwitching()
+{
+	return false;
+}
+
+bool PowerSupply::SupportsOvercurrentShutdown()
+{
+	return false;
+}
+
+bool PowerSupply::GetPowerChannelActive(int /*chan*/)
+{
+	return true;
+}
+
+//Configuration
+bool PowerSupply::GetPowerOvercurrentShutdownEnabled(int /*chan*/)
+{
+	return false;
+}
+
+void PowerSupply::SetPowerOvercurrentShutdownEnabled(int /*chan*/, bool /*enable*/)
+{
+}
+
+bool PowerSupply::GetPowerOvercurrentShutdownTripped(int /*chan*/)
+{
+	return false;
+}
+
+void PowerSupply::SetPowerChannelActive(int /*chan*/, bool /*on*/)
+{
+}
+
+bool PowerSupply::GetMasterPowerEnable()
+{
+	return true;
+}
+
+void PowerSupply::SetMasterPowerEnable(bool /*enable*/)
+{
+}
+
+//Soft start
+bool PowerSupply::IsSoftStartEnabled(int /*chan*/)
+{
+	return false;
+}
+
+void PowerSupply::SetSoftStartEnabled(int /*chan*/, bool /*enable*/)
+{
+}

--- a/scopehal/PowerSupply.h
+++ b/scopehal/PowerSupply.h
@@ -39,6 +39,8 @@ public:
 	PowerSupply();
 	virtual ~PowerSupply();
 
+	virtual unsigned int GetInstrumentTypes();
+
 	//Channel info
 	virtual int GetPowerChannelCount() =0;
 	virtual std::string GetPowerChannelName(int chan) =0;
@@ -50,7 +52,7 @@ public:
 		If this function returns false, IsSoftStartEnabled() will always return false,
 		and SetSoftStartEnabled() is a no-op.
 	 */
-	virtual bool SupportsSoftStart() =0;
+	virtual bool SupportsSoftStart();
 
 	/**
 		@brief Determines if the power supply supports switching individual output channels
@@ -58,7 +60,7 @@ public:
 		If this function returns false, GetPowerChannelActive() will always return true,
 		and SetPowerChannelActive() is a no-op.
 	 */
-	virtual bool SupportsIndividualOutputSwitching() =0;
+	virtual bool SupportsIndividualOutputSwitching();
 
 	/**
 		@brief Determines if the power supply supports ganged master switching of all outputs
@@ -66,7 +68,7 @@ public:
 		If this function returns false, GetMasterPowerEnable() will always return true,
 		and SetMasterPowerEnable() is a no-op.
 	 */
-	virtual bool SupportsMasterOutputSwitching() =0;
+	virtual bool SupportsMasterOutputSwitching();
 
 	/**
 		@brief Determines if the power supply supports shutdown rather than constant-current mode on overcurrent
@@ -74,32 +76,32 @@ public:
 		If this function returns false, GetPowerOvercurrentShutdownEnabled() and GetPowerOvercurrentShutdownTripped() will always return false,
 		and SetPowerOvercurrentShutdownEnabled() is a no-op.
 	 */
-	virtual bool SupportsOvercurrentShutdown() =0;
+	virtual bool SupportsOvercurrentShutdown();
 
 	//Read sensors
 	virtual double GetPowerVoltageActual(int chan) =0;				//actual voltage after current limiting
 	virtual double GetPowerVoltageNominal(int chan) =0;				//set point
 	virtual double GetPowerCurrentActual(int chan) =0;				//actual current drawn by the load
 	virtual double GetPowerCurrentNominal(int chan) =0;				//current limit
-	virtual bool GetPowerChannelActive(int chan) =0;
+	virtual bool GetPowerChannelActive(int chan);
 
 	//Configuration
-	virtual bool GetPowerOvercurrentShutdownEnabled(int chan) =0;	//shut channel off entirely on overload,
-																	//rather than current limiting
-	virtual void SetPowerOvercurrentShutdownEnabled(int chan, bool enable) =0;
-	virtual bool GetPowerOvercurrentShutdownTripped(int chan) =0;
+	virtual bool GetPowerOvercurrentShutdownEnabled(int chan);	//shut channel off entirely on overload,
+																//rather than current limiting
+	virtual void SetPowerOvercurrentShutdownEnabled(int chan, bool enable);
+	virtual bool GetPowerOvercurrentShutdownTripped(int chan);
 	virtual void SetPowerVoltage(int chan, double volts) =0;
 	virtual void SetPowerCurrent(int chan, double amps) =0;
-	virtual void SetPowerChannelActive(int chan, bool on) =0;
+	virtual void SetPowerChannelActive(int chan, bool on);
 
 	virtual bool IsPowerConstantCurrent(int chan) =0;				//true = CC, false = CV
 
-	virtual bool GetMasterPowerEnable() =0;
-	virtual void SetMasterPowerEnable(bool enable) = 0;
+	virtual bool GetMasterPowerEnable();
+	virtual void SetMasterPowerEnable(bool enable);
 
 	//Soft start
-	virtual bool IsSoftStartEnabled(int chan) =0;
-	virtual void SetSoftStartEnabled(int chan, bool enable) =0;
+	virtual bool IsSoftStartEnabled(int chan);
+	virtual void SetSoftStartEnabled(int chan, bool enable);
 };
 
 #endif

--- a/scopehal/PowerSupply.h
+++ b/scopehal/PowerSupply.h
@@ -43,6 +43,39 @@ public:
 	virtual int GetPowerChannelCount() =0;
 	virtual std::string GetPowerChannelName(int chan) =0;
 
+	//Device capabilities
+	/**
+		@brief Determines if the power supply supports soft start
+
+		If this function returns false, IsSoftStartEnabled() will always return false,
+		and SetSoftStartEnabled() is a no-op.
+	 */
+	virtual bool SupportsSoftStart() =0;
+
+	/**
+		@brief Determines if the power supply supports switching individual output channels
+
+		If this function returns false, GetPowerChannelActive() will always return true,
+		and SetPowerChannelActive() is a no-op.
+	 */
+	virtual bool SupportsIndividualOutputSwitching() =0;
+
+	/**
+		@brief Determines if the power supply supports ganged master switching of all outputs
+
+		If this function returns false, GetMasterPowerEnable() will always return true,
+		and SetMasterPowerEnable() is a no-op.
+	 */
+	virtual bool SupportsMasterOutputSwitching() =0;
+
+	/**
+		@brief Determines if the power supply supports shutdown rather than constant-current mode on overcurrent
+
+		If this function returns false, GetPowerOvercurrentShutdownEnabled() and GetPowerOvercurrentShutdownTripped() will always return false,
+		and SetPowerOvercurrentShutdownEnabled() is a no-op.
+	 */
+	virtual bool SupportsOvercurrentShutdown() =0;
+
 	//Read sensors
 	virtual double GetPowerVoltageActual(int chan) =0;				//actual voltage after current limiting
 	virtual double GetPowerVoltageNominal(int chan) =0;				//set point

--- a/scopehal/RohdeSchwarzHMC804xPowerSupply.cpp
+++ b/scopehal/RohdeSchwarzHMC804xPowerSupply.cpp
@@ -72,11 +72,6 @@ string RohdeSchwarzHMC804xPowerSupply::GetSerial()
 	return m_serial;
 }
 
-unsigned int RohdeSchwarzHMC804xPowerSupply::GetInstrumentTypes()
-{
-	return INST_PSU;
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Device capabilities
 

--- a/scopehal/RohdeSchwarzHMC804xPowerSupply.cpp
+++ b/scopehal/RohdeSchwarzHMC804xPowerSupply.cpp
@@ -78,6 +78,29 @@ unsigned int RohdeSchwarzHMC804xPowerSupply::GetInstrumentTypes()
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device capabilities
+
+bool RohdeSchwarzHMC804xPowerSupply::SupportsSoftStart()
+{
+	return true;
+}
+
+bool RohdeSchwarzHMC804xPowerSupply::SupportsIndividualOutputSwitching()
+{
+	return true;
+}
+
+bool RohdeSchwarzHMC804xPowerSupply::SupportsMasterOutputSwitching()
+{
+	return m_channelCount > 1;
+}
+
+bool RohdeSchwarzHMC804xPowerSupply::SupportsOvercurrentShutdown()
+{
+	return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Actual hardware interfacing
 
 bool RohdeSchwarzHMC804xPowerSupply::IsPowerConstantCurrent(int chan)

--- a/scopehal/RohdeSchwarzHMC804xPowerSupply.h
+++ b/scopehal/RohdeSchwarzHMC804xPowerSupply.h
@@ -42,44 +42,42 @@ public:
 	virtual ~RohdeSchwarzHMC804xPowerSupply();
 
 	//Device information
-	virtual std::string GetName();
-	virtual std::string GetVendor();
-	virtual std::string GetSerial();
-
-	virtual unsigned int GetInstrumentTypes();
+	std::string GetName() override;
+	std::string GetVendor() override;
+	std::string GetSerial() override;
 
 	//Device capabilities
-	virtual bool SupportsSoftStart();
-	virtual bool SupportsIndividualOutputSwitching();
-	virtual bool SupportsMasterOutputSwitching();
-	virtual bool SupportsOvercurrentShutdown();
+	bool SupportsSoftStart() override;
+	bool SupportsIndividualOutputSwitching() override;
+	bool SupportsMasterOutputSwitching() override;
+	bool SupportsOvercurrentShutdown() override;
 
 	//Channel info
-	virtual int GetPowerChannelCount();
-	virtual std::string GetPowerChannelName(int chan);
+	int GetPowerChannelCount() override;
+	std::string GetPowerChannelName(int chan) override;
 
 	//Read sensors
-	virtual double GetPowerVoltageActual(int chan);				//actual voltage after current limiting
-	virtual double GetPowerVoltageNominal(int chan);			//set point
-	virtual double GetPowerCurrentActual(int chan);				//actual current drawn by the load
-	virtual double GetPowerCurrentNominal(int chan);			//current limit
-	virtual bool GetPowerChannelActive(int chan);
+	double GetPowerVoltageActual(int chan) override;	//actual voltage after current limiting
+	double GetPowerVoltageNominal(int chan) override;	//set point
+	double GetPowerCurrentActual(int chan) override;	//actual current drawn by the load
+	double GetPowerCurrentNominal(int chan) override;	//current limit
+	bool GetPowerChannelActive(int chan) override;
 
 	//Configuration
-	virtual bool GetPowerOvercurrentShutdownEnabled(int chan);	//shut channel off entirely on overload,
+	bool GetPowerOvercurrentShutdownEnabled(int chan) override;	//shut channel off entirely on overload,
 																//rather than current limiting
-	virtual void SetPowerOvercurrentShutdownEnabled(int chan, bool enable);
-	virtual bool GetPowerOvercurrentShutdownTripped(int chan);
-	virtual void SetPowerVoltage(int chan, double volts);
-	virtual void SetPowerCurrent(int chan, double amps);
-	virtual void SetPowerChannelActive(int chan, bool on);
-	virtual bool IsPowerConstantCurrent(int chan);
+	void SetPowerOvercurrentShutdownEnabled(int chan, bool enable) override;
+	bool GetPowerOvercurrentShutdownTripped(int chan) override;
+	void SetPowerVoltage(int chan, double volts) override;
+	void SetPowerCurrent(int chan, double amps) override;
+	void SetPowerChannelActive(int chan, bool on) override;
+	bool IsPowerConstantCurrent(int chan) override;
 
-	virtual bool GetMasterPowerEnable();
-	virtual void SetMasterPowerEnable(bool enable);
+	bool GetMasterPowerEnable() override;
+	void SetMasterPowerEnable(bool enable) override;
 
-	virtual bool IsSoftStartEnabled(int chan);
-	virtual void SetSoftStartEnabled(int chan, bool enable);
+	bool IsSoftStartEnabled(int chan) override;
+	void SetSoftStartEnabled(int chan, bool enable) override;
 
 protected:
 	int GetStatusRegister(int chan);

--- a/scopehal/RohdeSchwarzHMC804xPowerSupply.h
+++ b/scopehal/RohdeSchwarzHMC804xPowerSupply.h
@@ -48,6 +48,12 @@ public:
 
 	virtual unsigned int GetInstrumentTypes();
 
+	//Device capabilities
+	virtual bool SupportsSoftStart();
+	virtual bool SupportsIndividualOutputSwitching();
+	virtual bool SupportsMasterOutputSwitching();
+	virtual bool SupportsOvercurrentShutdown();
+
 	//Channel info
 	virtual int GetPowerChannelCount();
 	virtual std::string GetPowerChannelName(int chan);

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -47,11 +47,13 @@
 #include "PicoOscilloscope.h"
 #include "RigolOscilloscope.h"
 #include "RohdeSchwarzOscilloscope.h"
+#include "SCPIPowerSupply.h"
 #include "SiglentSCPIOscilloscope.h"
 #include "TektronixOscilloscope.h"
 
 #include "RohdeSchwarzHMC8012Multimeter.h"
 
+#include "GWInstekGPDX303SPowerSupply.h"
 #include "RohdeSchwarzHMC804xPowerSupply.h"
 
 #include "SiglentVectorSignalGenerator.h"
@@ -189,6 +191,7 @@ void DriverStaticInit()
 
 	AddMultimeterDriverClass(RohdeSchwarzHMC8012Multimeter);
 
+	AddPowerSupplyDriverClass(GWInstekGPDX303SPowerSupply);
 	AddPowerSupplyDriverClass(RohdeSchwarzHMC804xPowerSupply);
 
 	AddRFSignalGeneratorDriverClass(SiglentVectorSignalGenerator);


### PR DESCRIPTION
This PR adds support for the basic features of the GW Instead GPD-X303S series power supplies, tested against a GPD-3303S with a macOS build of ngscopeclient. Several extensions were made to the PowerSupply.h interface to allow querying for features that distinguish these supplies from the existing R&S HMC804x power supplies that are supported.

Future work includes adding support for tracking series/parallel modes - as I started taking a look at the changes that would entail, it was going to take some more thought.

This is my first scopehal driver - let me know if there's anything that I can adjust to better fit in the existing codebase. I added some doxygen comments for the new power supply feature support query methods. There does not seem to be any documentation in `scopehal-docs` regarding power supply support, but if you'd like to establish some before landing this I can see about putting something together.