### PR TITLE
Rigol MSO5000 Fixes

### DIFF
--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -709,9 +709,6 @@ bool RigolOscilloscope::AcquireData()
 {
 	//LogDebug("Acquiring data\n");
 
-	//TODO
-	bool enabled[4] = {true, true, true, true};
-
 	lock_guard<recursive_mutex> lock(m_mutex);
 	LogIndenter li;
 
@@ -737,7 +734,7 @@ bool RigolOscilloscope::AcquireData()
 	map<int, vector<UniformAnalogWaveform*>> pending_waveforms;
 	for(size_t i = 0; i < m_analogChannelCount; i++)
 	{
-		if(!enabled[i])
+		if(!IsChannelEnabled(i))
 			continue;
 
 		//LogDebug("Channel %zu\n", i);
@@ -881,7 +878,7 @@ bool RigolOscilloscope::AcquireData()
 		SequenceSet s;
 		for(size_t j = 0; j < m_analogChannelCount; j++)
 		{
-			if(enabled[j])
+			if(pending_waveforms.count(j) > 0)
 				s[m_channels[j]] = pending_waveforms[j][i];
 		}
 		m_pendingWaveforms.push_back(s);

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -797,6 +797,7 @@ bool RigolOscilloscope::AcquireData()
 			if(m_protocol == MSO5)
 			{
 				//Ask for the data block
+				m_transport->SendCommand("*WAI");
 				m_transport->SendCommand("WAV:DATA?");
 			}
 			else if(m_protocol == DS_OLD)

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -82,6 +82,8 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 			// Reset memory depth
 			m_transport->SendCommand("ACQ:MDEP 1M\n");
 
+			string originalBandwidthLimit = m_transport->SendCommandImmediateWithReply("CHAN1:BWL?");
+
 			// Figure out its actual bandwidth since :SYST:OPT:STAT is practically useless
 			m_transport->SendCommand("CHAN1:BWL 200M\n");
 			m_transport->SendCommand("CHAN1:BWL?\n");
@@ -106,6 +108,8 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 						m_bandwidth = 70;
 				}
 			}
+
+			m_transport->SendCommandImmediate("CHAN1:BWL " + originalBandwidthLimit);
 		}
 	}
 	else


### PR DESCRIPTION
This PR fixes a crash with the Rigol MSO5000 where if waveform data was requested too quickly after a trigger event, the scope would send a response header but no waveform data to follow it. Additionally, there are some quality-of-life improvements/bugfixes.