### PR TITLE
Add missing pool size for eStorageImage descriptor

### DIFF
--- a/scopehal/ComputePipeline.cpp
+++ b/scopehal/ComputePipeline.cpp
@@ -101,12 +101,18 @@ void ComputePipeline::DeferredInit()
 		std::move(g_vkComputeDevice->createComputePipelines(*cache, pinfo).front()));
 
 	//Descriptor pool for our shader parameters
-	vk::DescriptorPoolSize poolSize(vk::DescriptorType::eStorageBuffer, m_numSSBOs);
+	vk::DescriptorPoolSize ssboPoolSize(vk::DescriptorType::eStorageBuffer, m_numSSBOs);
+	vk::DescriptorPoolSize imagePoolSize(vk::DescriptorType::eStorageImage, m_numImages);
+	vk::DescriptorPoolSize poolSizes[2] =
+	{
+		ssboPoolSize,
+		imagePoolSize
+	};
 	vk::DescriptorPoolCreateInfo poolInfo(
 		vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet |
 			vk::DescriptorPoolCreateFlagBits::eUpdateAfterBind,
 		1,
-		poolSize);
+		poolSizes);
 	m_descriptorPool = make_unique<vk::raii::DescriptorPool>(*g_vkComputeDevice, poolInfo);
 
 	//Set up descriptors for our buffers


### PR DESCRIPTION
MoltenVK seems to validate the descriptors pretty strictly and this was returning eErrorOutOfPoolMemory due to the lack of a provided pool of eStorageImage.