### PR TITLE
Precompile selected headers to improve compile times

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -211,6 +211,14 @@ PUBLIC SYSTEM
 	${CMAKE_CURRENT_SOURCE_DIR}/../VkFFT/vkFFT
 	)
 
+target_precompile_headers(scopehal
+PUBLIC
+	${Vulkan_INCLUDE_DIR}/vulkan/vulkan_raii.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../VkFFT/vkFFT/vkFFT.h
+	${GTKMM_INCLUDEDIR}/gtkmm-3.0/gtkmm.h
+	${YAML_INCLUDES}/yaml-cpp/yaml.h
+	)
+
 if(${HAS_LXI})
 	target_compile_definitions(scopehal PUBLIC HAS_LXI)
 endif()


### PR DESCRIPTION
Precompiling these system/library headers takes a clean build of ngscopeclient from ~100-135s to ~40-45 seconds on my MacBook, a 60+% improvement.

Incremental rebuild speed is still suboptimal, since a change in pretty much any header file will cause every .cpp file to be recompiled. I may clean up an experimental branch that removes library-internal usage of `scopehal.h` and `scope protocols.h` to improve this situation as follow-up work.