### PR TITLE
Hardcode the windows yaml-cpp path even more.

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -222,7 +222,7 @@ PUBLIC
 	${GTKMM_INCLUDEDIR}/gtkmm-3.0/gtkmm.h
 	# YAML_INCLUDES isn't set on win32 because we're not using `find_package` above.
 	# Hard-code an include path for now.
-	$<$<BOOL:${WIN32}>:/mingw64/include/yaml-cpp/yaml.h,${YAML_INCLUDES}/yaml-cpp/yaml.h>
+	$<$<BOOL:${WIN32}>:"D:/a/_temp/mingw64/include/yaml-cpp/yaml.h",${YAML_INCLUDES}/yaml-cpp/yaml.h>
 	)
 
 if(${HAS_LXI})


### PR DESCRIPTION
The build still wasn't happy with my fix in #702 (https://github.com/glscopeclient/scopehal-apps/actions/runs/3169429026/jobs/5161334902), so tack on the rest of the path as well.