### PR TITLE
Fix compile issues on x86_64 clang

### DIFF
--- a/scopehal/avx_mathfun.h
+++ b/scopehal/avx_mathfun.h
@@ -51,10 +51,15 @@ typedef __m256  v8sf; // vector of 8 float (avx)
 typedef __m256i v8si; // vector of 8 int   (avx)
 
 //Added function prototypes
+__attribute__((target("avx2")))
 v8sf _mm256_log_ps(v8sf);
+__attribute__((target("avx2")))
 v8sf exp256_ps(v8sf);
+__attribute__((target("avx2")))
 v8sf _mm256_sin_ps(v8sf);
+__attribute__((target("avx2")))
 v8sf _mm256_cos_ps(v8sf);
+__attribute__((target("avx2")))
 void _mm256_sincos_ps(v8sf xx, v8sf*, v8sf*);
 
 /* declare some AVX constants -- why can't I figure a better way to do that? */


### PR DESCRIPTION
Add AVX2 feature attributes to avx_mathfun header. This seems to be needed for clang to properly compile with the correct ABI. Without this change, clang requires the whole binary to be linked with -mavx to avoid error, presumably because the function's interface types change the ABI.