### PR TITLE
Initial GTK Refactor

### DIFF
--- a/scopeexports/CMakeLists.txt
+++ b/scopeexports/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(SYSTEM ${GTKMM_INCLUDE_DIRS} ${SIGCXX_INCLUDE_DIRS})
 link_directories(${GTKMM_LIBRARY_DIRS} ${SIGCXX_LIBRARY_DIRS})
 
 set(SCOPEEXPORTS_SOURCES
+	ExportWizard.cpp
 	CSVExportWizard.cpp
 	TouchstoneExportWizard.cpp
 	VCDExportWizard.cpp

--- a/scopeexports/CSVExportWizard.cpp
+++ b/scopeexports/CSVExportWizard.cpp
@@ -32,7 +32,7 @@
 	@author Andrew D. Zonenberg
 	@brief Implementation of CSVExportWizard
  */
-#include "scopehal.h"
+#include "scopeexports.h"
 #include "CSVExportWizard.h"
 
 using namespace std;

--- a/scopeexports/ExportWizard.cpp
+++ b/scopeexports/ExportWizard.cpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
 *                                                                                                                      *
-* libscopehal v0.1                                                                                                     *
+* libscopeexports                                                                                                      *
 *                                                                                                                      *
 * Copyright (c) 2012-2022 Andrew D. Zonenberg and contributors                                                         *
 * All rights reserved.                                                                                                 *
@@ -32,7 +32,8 @@
 	@author Andrew D. Zonenberg
 	@brief Implementation of ExportWizard
  */
-#include "scopehal.h"
+#include "scopeexports.h"
+#include "ExportWizard.h"
 
 using namespace std;
 

--- a/scopeexports/ExportWizard.h
+++ b/scopeexports/ExportWizard.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
 *                                                                                                                      *
-* libscopehal v0.1                                                                                                     *
+* libscopeexports                                                                                                      *
 *                                                                                                                      *
 * Copyright (c) 2012-2022 Andrew D. Zonenberg and contributors                                                         *
 * All rights reserved.                                                                                                 *

--- a/scopeexports/TouchstoneExportWizard.cpp
+++ b/scopeexports/TouchstoneExportWizard.cpp
@@ -32,7 +32,7 @@
 	@author Andrew D. Zonenberg
 	@brief Implementation of TouchstoneExportWizard
  */
-#include "scopehal.h"
+#include "scopeexports.h"
 #include "TouchstoneExportWizard.h"
 
 using namespace std;

--- a/scopeexports/VCDExportWizard.cpp
+++ b/scopeexports/VCDExportWizard.cpp
@@ -32,7 +32,7 @@
 	@author Andrew D. Zonenberg
 	@brief Implementation of VCDExportWizard
  */
-#include "scopehal.h"
+#include "scopeexports.h"
 #include "VCDExportWizard.h"
 
 using namespace std;

--- a/scopeexports/scopeexports.h
+++ b/scopeexports/scopeexports.h
@@ -37,7 +37,10 @@
 #define scopeexports_h
 
 #include "../scopehal/scopehal.h"
-#include "../scopehal/ExportWizard.h"
+
+#include <gtkmm.h>
+
+#include "ExportWizard.h"
 
 void ScopeExportStaticInit();
 

--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 set(SCOPEHAL_SOURCES
 	base64.cpp
 	scopehal.cpp
+	ScopehalUtil.cpp
 	avx_mathfun.cpp
 	VulkanInit.cpp
 
@@ -150,7 +151,7 @@ target_link_libraries(scopehal
 	${GTKMM_LIBRARIES}
 	xptools
 	log
-	graphwidget
+	# graphwidget
 	${YAML_LIBRARIES}
 	${LXI_LIBRARIES}
 	${LINUXGPIB_LIBRARIES}
@@ -178,7 +179,7 @@ target_link_libraries(scopehal
 	${GTKMM_LIBRARIES}
 	xptools
 	log
-	graphwidget
+	# graphwidget
 	${YAML_LIBRARIES}
 	${LXI_LIBRARIES}
 	${LINUXGPIB_LIBRARIES}

--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -226,7 +226,6 @@ PUBLIC
 
 	${Vulkan_INCLUDE_DIR}/vulkan/vulkan_raii.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/../VkFFT/vkFFT/vkFFT.h
-	${GTKMM_INCLUDEDIR}/gtkmm-3.0/gtkmm.h
 	${YAML_PCH_PATH}
 	)
 

--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -131,7 +131,6 @@ set(SCOPEHAL_SOURCES
 	TestWaveformSource.cpp
 
 	ComputePipeline.cpp
-	ExportWizard.cpp
 	FilterGraphExecutor.cpp
 	PipelineCacheManager.cpp
 	VulkanFFTPlan.cpp
@@ -151,7 +150,6 @@ target_link_libraries(scopehal
 	${GTKMM_LIBRARIES}
 	xptools
 	log
-	# graphwidget
 	${YAML_LIBRARIES}
 	${LXI_LIBRARIES}
 	${LINUXGPIB_LIBRARIES}
@@ -179,7 +177,6 @@ target_link_libraries(scopehal
 	${GTKMM_LIBRARIES}
 	xptools
 	log
-	# graphwidget
 	${YAML_LIBRARIES}
 	${LXI_LIBRARIES}
 	${LINUXGPIB_LIBRARIES}

--- a/scopehal/PacketDecoder.cpp
+++ b/scopehal/PacketDecoder.cpp
@@ -33,15 +33,15 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Color schemes
 
-Gdk::Color PacketDecoder::m_backgroundColors[PROTO_STANDARD_COLOR_COUNT] =
+std::string PacketDecoder::m_backgroundColors[PROTO_STANDARD_COLOR_COUNT] =
 {
-	Gdk::Color("#101010"),		//PROTO_COLOR_DEFAULT
-	Gdk::Color("#800000"),		//PROTO_COLOR_ERROR
-	Gdk::Color("#000080"),		//PROTO_COLOR_STATUS
-	Gdk::Color("#808000"),		//PROTO_COLOR_CONTROL
-	Gdk::Color("#336699"),		//PROTO_COLOR_DATA_READ
-	Gdk::Color("#339966"),		//PROTO_COLOR_DATA_WRITE
-	Gdk::Color("#600050"),		//PROTO_COLOR_COMMAND
+	"#101010",		//PROTO_COLOR_DEFAULT
+	"#800000",		//PROTO_COLOR_ERROR
+	"#000080",		//PROTO_COLOR_STATUS
+	"#808000",		//PROTO_COLOR_CONTROL
+	"#336699",		//PROTO_COLOR_DATA_READ
+	"#339966",		//PROTO_COLOR_DATA_WRITE
+	"#600050",		//PROTO_COLOR_COMMAND
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -50,7 +50,7 @@ Gdk::Color PacketDecoder::m_backgroundColors[PROTO_STANDARD_COLOR_COUNT] =
 Packet::Packet()
 	: m_offset(0)
 	, m_len(0)
-	, m_displayForegroundColor(Gdk::Color("#ffffff"))
+	, m_displayForegroundColor("#ffffff")
 	, m_displayBackgroundColor(PacketDecoder::m_backgroundColors[PacketDecoder::PROTO_COLOR_DEFAULT])
 {
 }

--- a/scopehal/PacketDecoder.h
+++ b/scopehal/PacketDecoder.h
@@ -55,10 +55,10 @@ public:
 	std::vector<uint8_t> m_data;
 
 	//Text color of the packet
-	Gdk::Color m_displayForegroundColor;
+	std::string m_displayForegroundColor;
 
 	//Background color of the packet
-	Gdk::Color m_displayBackgroundColor;
+	std::string m_displayBackgroundColor;
 };
 
 /**
@@ -100,7 +100,7 @@ public:
 		PROTO_STANDARD_COLOR_COUNT
 	};
 
-	static Gdk::Color m_backgroundColors[PROTO_STANDARD_COLOR_COUNT];
+	static std::string m_backgroundColors[PROTO_STANDARD_COLOR_COUNT];
 
 protected:
 	void ClearPackets();

--- a/scopehal/ScopehalUtil.cpp
+++ b/scopehal/ScopehalUtil.cpp
@@ -1,0 +1,44 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2022 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@author Andrew D. Zonenberg
+	@brief Implementation of global utility functions
+ */
+ #include "ScopehalUtil.h"
+
+double GetTime()
+{
+	timespec t;
+	clock_gettime(CLOCK_REALTIME,&t);
+	double d = static_cast<double>(t.tv_nsec) / 1E9f;
+	d += t.tv_sec;
+	return d;
+}

--- a/scopehal/ScopehalUtil.h
+++ b/scopehal/ScopehalUtil.h
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2022 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@author Andrew D. Zonenberg
+	@brief Declaration of global utility functions
+ */
+
+#ifndef ScopehalUtil_h
+#define ScopehalUtil_h
+
+double GetTime();
+
+#endif

--- a/scopehal/StandardColors.cpp
+++ b/scopehal/StandardColors.cpp
@@ -31,15 +31,15 @@
 
 namespace StandardColors
 {
-	Gdk::Color colors[StandardColors::STANDARD_COLOR_COUNT] =
+	std::string colors[StandardColors::STANDARD_COLOR_COUNT] =
 	{
-		Gdk::Color("#336699"),	//COLOR_DATA
-		Gdk::Color("#c000a0"),	//COLOR_CONTROL
-		Gdk::Color("#ffff00"),	//COLOR_ADDRESS
-		Gdk::Color("#808080"),	//COLOR_PREAMBLE
-		Gdk::Color("#00ff00"),	//COLOR_CHECKSUM_OK
-		Gdk::Color("#ff0000"),	//COLOR_CHECKSUM_BAD
-		Gdk::Color("#ff0000"),	//COLOR_ERROR
-		Gdk::Color("#404040")	//COLOR_IDLE
+		"#336699",	//COLOR_DATA
+		"#c000a0",	//COLOR_CONTROL
+		"#ffff00",	//COLOR_ADDRESS
+		"#808080",	//COLOR_PREAMBLE
+		"#00ff00",	//COLOR_CHECKSUM_OK
+		"#ff0000",	//COLOR_CHECKSUM_BAD
+		"#ff0000",	//COLOR_ERROR
+		"#404040"	//COLOR_IDLE
 	};
 }

--- a/scopehal/StandardColors.h
+++ b/scopehal/StandardColors.h
@@ -30,10 +30,6 @@
 #ifndef StandardColors_h
 #define StandardColors_h
 
-#include <gtkmm.h>
-
-// TODO: This doesn't seem like it belongs in scopehal
-
 namespace StandardColors
 {
 	enum FilterColor

--- a/scopehal/StandardColors.h
+++ b/scopehal/StandardColors.h
@@ -50,7 +50,7 @@ namespace StandardColors
 		STANDARD_COLOR_COUNT
 	};
 
-	extern Gdk::Color colors[STANDARD_COLOR_COUNT];
+	extern std::string colors[STANDARD_COLOR_COUNT];
 }
 
 #endif // StandardColors_h

--- a/scopehal/Waveform.h
+++ b/scopehal/Waveform.h
@@ -138,7 +138,7 @@ public:
 		return "(unimplemented)";
 	}
 
-	virtual Gdk::Color GetColor(size_t /*i*/)
+	virtual std::string GetColor(size_t /*i*/)
 	{
 		return StandardColors::colors[StandardColors::COLOR_ERROR];
 	}

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -33,7 +33,6 @@
 	@brief Implementation of global functions
  */
 #include "scopehal.h"
-#include <gtkmm/drawingarea.h>
 #include <libgen.h>
 
 #include "AgilentOscilloscope.h"

--- a/scopehal/scopehal.h
+++ b/scopehal/scopehal.h
@@ -52,7 +52,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include "../log/log.h"
-#include "../graphwidget/Graph.h"
+#include "ScopehalUtil.h"
 
 #include "config.h"
 

--- a/scopehal/scopehal.h
+++ b/scopehal/scopehal.h
@@ -46,6 +46,7 @@
 #include <chrono>
 #include <thread>
 #include <memory>
+#include <climits>
 
 #include <dirent.h>
 #include <float.h>

--- a/scopehal/scopehal.h
+++ b/scopehal/scopehal.h
@@ -38,6 +38,7 @@
 
 #define __USE_MINGW_ANSI_STDIO 1 // Required for MSYS2 mingw64 to support format "%z" ..
 
+#include <deque>
 #include <vector>
 #include <string>
 #include <map>
@@ -46,8 +47,11 @@
 #include <thread>
 #include <memory>
 
+#include <dirent.h>
+#include <float.h>
+#include <unistd.h>
+
 #include <sigc++/sigc++.h>
-#include <cairomm/context.h>
 
 #include <yaml-cpp/yaml.h>
 
@@ -123,7 +127,6 @@ extern bool g_hasAvx2;
 #include "SParameterSourceFilter.h"
 #include "SParameterFilter.h"
 
-#include "ExportWizard.h"
 #include "FilterGraphExecutor.h"
 
 uint64_t ConvertVectorSignalToScalar(const std::vector<bool>& bits);

--- a/scopeprotocols/ADL5205Decoder.cpp
+++ b/scopeprotocols/ADL5205Decoder.cpp
@@ -159,9 +159,9 @@ void ADL5205Decoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color ADL5205Waveform::GetColor(size_t /*i*/)
+string ADL5205Waveform::GetColor(size_t /*i*/)
 {
-	return Gdk::Color(m_color);
+	return m_color;
 }
 
 string ADL5205Waveform::GetText(size_t i)

--- a/scopeprotocols/ADL5205Decoder.h
+++ b/scopeprotocols/ADL5205Decoder.h
@@ -60,7 +60,7 @@ class ADL5205Waveform : public SparseWaveform<ADL5205Symbol>
 public:
 	ADL5205Waveform (const std::string& color) : SparseWaveform<ADL5205Symbol>(), m_color(color) {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 
 private:
 	const std::string& m_color;

--- a/scopeprotocols/CANDecoder.cpp
+++ b/scopeprotocols/CANDecoder.cpp
@@ -536,7 +536,7 @@ void CANDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color CANWaveform::GetColor(size_t i)
+std::string CANWaveform::GetColor(size_t i)
 {
 	const CANSymbol& s = m_samples[i];
 

--- a/scopeprotocols/CANDecoder.h
+++ b/scopeprotocols/CANDecoder.h
@@ -81,7 +81,7 @@ class CANWaveform : public SparseWaveform<CANSymbol>
 public:
 	CANWaveform () : SparseWaveform<CANSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class CANDecoder : public PacketDecoder

--- a/scopeprotocols/DPhyDataDecoder.cpp
+++ b/scopeprotocols/DPhyDataDecoder.cpp
@@ -367,7 +367,7 @@ void DPhyDataDecoder::Refresh()
 	SetData(cap, 0);
 }
 
-Gdk::Color DPhyDataWaveform::GetColor(size_t i)
+string DPhyDataWaveform::GetColor(size_t i)
 {
 	const DPhyDataSymbol& s = m_samples[i];
 

--- a/scopeprotocols/DPhyDataDecoder.h
+++ b/scopeprotocols/DPhyDataDecoder.h
@@ -66,7 +66,7 @@ class DPhyDataWaveform : public SparseWaveform<DPhyDataSymbol>
 public:
 	DPhyDataWaveform () : SparseWaveform<DPhyDataSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class DPhyDataDecoder : public Filter

--- a/scopeprotocols/DPhyEscapeModeDecoder.cpp
+++ b/scopeprotocols/DPhyEscapeModeDecoder.cpp
@@ -308,7 +308,7 @@ void DPhyEscapeModeDecoder::Refresh()
 	}
 }
 
-Gdk::Color DPhyEscapeModeWaveform::GetColor(size_t i)
+std::string DPhyEscapeModeWaveform::GetColor(size_t i)
 {
 	const DPhyEscapeModeSymbol& s = m_samples[i];
 

--- a/scopeprotocols/DPhyEscapeModeDecoder.h
+++ b/scopeprotocols/DPhyEscapeModeDecoder.h
@@ -67,7 +67,7 @@ class DPhyEscapeModeWaveform : public SparseWaveform<DPhyEscapeModeSymbol>
 public:
 	DPhyEscapeModeWaveform () : SparseWaveform<DPhyEscapeModeSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class DPhyEscapeModeDecoder : public PacketDecoder

--- a/scopeprotocols/DPhySymbolDecoder.cpp
+++ b/scopeprotocols/DPhySymbolDecoder.cpp
@@ -321,7 +321,7 @@ void DPhySymbolDecoder::Refresh()
 }
 
 
-Gdk::Color DPhySymbolWaveform::GetColor(size_t i)
+string DPhySymbolWaveform::GetColor(size_t i)
 {
 	const DPhySymbol& s = m_samples[i];
 

--- a/scopeprotocols/DPhySymbolDecoder.h
+++ b/scopeprotocols/DPhySymbolDecoder.h
@@ -68,7 +68,7 @@ class DPhySymbolWaveform : public SparseWaveform<DPhySymbol>
 public:
 	DPhySymbolWaveform () : SparseWaveform<DPhySymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 /**

--- a/scopeprotocols/DSIFrameDecoder.cpp
+++ b/scopeprotocols/DSIFrameDecoder.cpp
@@ -283,7 +283,7 @@ void DSIFrameDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color DSIFrameWaveform::GetColor(size_t i)
+string DSIFrameWaveform::GetColor(size_t i)
 {
 	auto s = m_samples[i];
 	switch(s.m_type)
@@ -294,9 +294,9 @@ Gdk::Color DSIFrameWaveform::GetColor(size_t i)
 
 		case DSIFrameSymbol::TYPE_VIDEO:
 			{
-				Gdk::Color ret;
-				ret.set_rgb_p(s.m_red / 255.0f, s.m_green / 255.0f, s.m_blue / 255.0f);
-				return ret;
+				char buf[10];
+				snprintf(buf, sizeof(buf), "#%02X%02X%02X", s.m_red, s.m_green, s.m_blue);
+				return buf;
 			}
 
 		case DSIFrameSymbol::TYPE_ERROR:

--- a/scopeprotocols/DSIFrameDecoder.h
+++ b/scopeprotocols/DSIFrameDecoder.h
@@ -76,7 +76,7 @@ class DSIFrameWaveform : public SparseWaveform<DSIFrameSymbol>
 public:
 	DSIFrameWaveform () : SparseWaveform<DSIFrameSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class DSIFrameDecoder : public PacketDecoder

--- a/scopeprotocols/DSIPacketDecoder.cpp
+++ b/scopeprotocols/DSIPacketDecoder.cpp
@@ -507,7 +507,7 @@ void DSIPacketDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color DSIWaveform::GetColor(size_t i)
+std::string DSIWaveform::GetColor(size_t i)
 {
 	const DSISymbol& s = m_samples[i];
 	switch(s.m_stype)

--- a/scopeprotocols/DSIPacketDecoder.h
+++ b/scopeprotocols/DSIPacketDecoder.h
@@ -72,7 +72,7 @@ class DSIWaveform : public SparseWaveform<DSISymbol>
 public:
 	DSIWaveform () : SparseWaveform<DSISymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 /**

--- a/scopeprotocols/DVIDecoder.cpp
+++ b/scopeprotocols/DVIDecoder.cpp
@@ -277,7 +277,7 @@ void DVIDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color DVIWaveform::GetColor(size_t i)
+std::string DVIWaveform::GetColor(size_t i)
 {
 	auto s = m_samples[i];
 	switch(s.m_type)
@@ -291,9 +291,9 @@ Gdk::Color DVIWaveform::GetColor(size_t i)
 
 		case DVISymbol::DVI_TYPE_VIDEO:
 			{
-				Gdk::Color ret;
-				ret.set_rgb_p(s.m_red / 255.0f, s.m_green / 255.0f, s.m_blue / 255.0f);
-				return ret;
+				char buf[10];
+				snprintf(buf, sizeof(buf), "#%02X%02X%02X", s.m_red, s.m_green, s.m_blue);
+				return buf;
 			}
 
 		case DVISymbol::DVI_TYPE_ERROR:

--- a/scopeprotocols/DVIDecoder.h
+++ b/scopeprotocols/DVIDecoder.h
@@ -83,7 +83,7 @@ class DVIWaveform : public SparseWaveform<DVISymbol>
 public:
 	DVIWaveform () : SparseWaveform<DVISymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class DVIDecoder : public PacketDecoder

--- a/scopeprotocols/ESPIDecoder.cpp
+++ b/scopeprotocols/ESPIDecoder.cpp
@@ -1410,7 +1410,7 @@ uint8_t ESPIDecoder::UpdateCRC8(uint8_t crc, uint8_t data)
 	return crc;
 }
 
-Gdk::Color ESPIWaveform::GetColor(size_t i)
+std::string ESPIWaveform::GetColor(size_t i)
 {
 	const ESPISymbol& s = m_samples[i];
 

--- a/scopeprotocols/ESPIDecoder.h
+++ b/scopeprotocols/ESPIDecoder.h
@@ -189,7 +189,7 @@ class ESPIWaveform : public SparseWaveform<ESPISymbol>
 public:
 	ESPIWaveform () : SparseWaveform<ESPISymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 /**

--- a/scopeprotocols/Ethernet64b66bDecoder.cpp
+++ b/scopeprotocols/Ethernet64b66bDecoder.cpp
@@ -180,7 +180,7 @@ void Ethernet64b66bDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color Ethernet64b66bWaveform::GetColor(size_t i)
+std::string Ethernet64b66bWaveform::GetColor(size_t i)
 {
 	const Ethernet64b66bSymbol& s = m_samples[i];
 

--- a/scopeprotocols/Ethernet64b66bDecoder.h
+++ b/scopeprotocols/Ethernet64b66bDecoder.h
@@ -61,7 +61,7 @@ class Ethernet64b66bWaveform : public SparseWaveform<Ethernet64b66bSymbol>
 public:
 	Ethernet64b66bWaveform () : SparseWaveform<Ethernet64b66bSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class Ethernet64b66bDecoder : public Filter

--- a/scopeprotocols/EthernetAutonegotiationDecoder.cpp
+++ b/scopeprotocols/EthernetAutonegotiationDecoder.cpp
@@ -162,7 +162,7 @@ void EthernetAutonegotiationDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color EthernetAutonegotiationWaveform::GetColor(size_t /*i*/)
+std::string EthernetAutonegotiationWaveform::GetColor(size_t /*i*/)
 {
 	return StandardColors::colors[StandardColors::COLOR_DATA];
 }

--- a/scopeprotocols/EthernetAutonegotiationDecoder.h
+++ b/scopeprotocols/EthernetAutonegotiationDecoder.h
@@ -42,7 +42,7 @@ public:
 	EthernetAutonegotiationWaveform () : SparseWaveform<uint16_t>() {};
 
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class EthernetAutonegotiationDecoder : public Filter

--- a/scopeprotocols/EthernetProtocolDecoder.cpp
+++ b/scopeprotocols/EthernetProtocolDecoder.cpp
@@ -333,8 +333,8 @@ void EthernetProtocolDecoder::BytesToFrames(
 					{
 						//Default to unknown LLC
 						pack->m_headers["Ethertype"] = "LLC";
-						pack->m_displayBackgroundColor = Gdk::Color("#33a02c");
-						pack->m_displayForegroundColor = Gdk::Color("#000000");
+						pack->m_displayBackgroundColor = "#33a02c";
+						pack->m_displayForegroundColor = "#000000";
 
 						//Look up the LLC LSAP address to see what it is
 						if( (i+1) < bytes.size() )
@@ -342,8 +342,8 @@ void EthernetProtocolDecoder::BytesToFrames(
 							if(bytes[i+1] == 0x42)
 							{
 								pack->m_headers["Ethertype"] = "STP";
-								pack->m_displayBackgroundColor = Gdk::Color("#fdbf6f");
-								pack->m_displayForegroundColor = Gdk::Color("#000000");
+								pack->m_displayBackgroundColor = "#fdbf6f";
+								pack->m_displayForegroundColor = "#000000";
 							}
 						}
 					}
@@ -354,27 +354,27 @@ void EthernetProtocolDecoder::BytesToFrames(
 						{
 							case 0x0800:
 								pack->m_headers["Ethertype"] = "IPv4";
-								pack->m_displayBackgroundColor = Gdk::Color("#a6cee3");
-								pack->m_displayForegroundColor = Gdk::Color("#000000");
+								pack->m_displayBackgroundColor = "#a6cee3";
+								pack->m_displayForegroundColor = "#000000";
 								break;
 
 							case 0x0806:
 								pack->m_headers["Ethertype"] = "ARP";
-								pack->m_displayBackgroundColor = Gdk::Color("#ffff99");
-								pack->m_displayForegroundColor = Gdk::Color("#000000");
+								pack->m_displayBackgroundColor = "#ffff99";
+								pack->m_displayForegroundColor = "#000000";
 								break;
 
 							//TODO: decoder inner ethertype too?
 							case 0x8100:
 								pack->m_headers["Ethertype"] = "802.1q";
-								pack->m_displayBackgroundColor = Gdk::Color("#b2df8a");
-								pack->m_displayForegroundColor = Gdk::Color("#000000");
+								pack->m_displayBackgroundColor = "#b2df8a";
+								pack->m_displayForegroundColor = "#000000";
 								break;
 
 							case 0x86DD:
 								pack->m_headers["Ethertype"] = "IPv6";
-								pack->m_displayBackgroundColor = Gdk::Color("#1f78b4");
-								pack->m_displayForegroundColor = Gdk::Color("#ffffff");
+								pack->m_displayBackgroundColor = "#1f78b4";
+								pack->m_displayForegroundColor = "#ffffff";
 								break;
 
 							default:
@@ -382,8 +382,8 @@ void EthernetProtocolDecoder::BytesToFrames(
 								segment.m_data[0],
 								segment.m_data[1]);
 								pack->m_headers["Ethertype"] = tmp;
-								pack->m_displayBackgroundColor = Gdk::Color("#fb9a99");
-								pack->m_displayForegroundColor = Gdk::Color("#000000");
+								pack->m_displayBackgroundColor = "#fb9a99";
+								pack->m_displayForegroundColor = "#000000";
 								break;
 						}
 					}
@@ -476,7 +476,7 @@ void EthernetProtocolDecoder::BytesToFrames(
 					{
 						segment.m_type = EthernetFrameSegment::TYPE_FCS_BAD;
 						pack->m_displayBackgroundColor = m_backgroundColors[PROTO_COLOR_ERROR];
-						pack->m_displayForegroundColor = Gdk::Color("#ffffff");
+						pack->m_displayForegroundColor = "#ffffff";
 					}
 
 					cap->m_durations.push_back( (ends[i] - start)/ cap->m_timescale);
@@ -498,7 +498,7 @@ void EthernetProtocolDecoder::BytesToFrames(
 	delete pack;
 }
 
-Gdk::Color EthernetWaveform::GetColor(size_t i)
+std::string EthernetWaveform::GetColor(size_t i)
 {
 	switch(m_samples[i].m_type)
 	{

--- a/scopeprotocols/EthernetProtocolDecoder.h
+++ b/scopeprotocols/EthernetProtocolDecoder.h
@@ -84,7 +84,7 @@ public:
 		: SparseWaveform<EthernetFrameSegment>()
 	{};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class EthernetProtocolDecoder : public PacketDecoder

--- a/scopeprotocols/EyeMask.h
+++ b/scopeprotocols/EyeMask.h
@@ -35,6 +35,8 @@
 #ifndef EyeMask_h
 #define EyeMask_h
 
+#include <cairomm/cairomm.h>
+
 class EyeDecoder2;
 class EyeWaveform;
 

--- a/scopeprotocols/HyperRAMDecoder.cpp
+++ b/scopeprotocols/HyperRAMDecoder.cpp
@@ -393,7 +393,7 @@ struct HyperRAMDecoder::CA HyperRAMDecoder::DecodeCA(uint64_t data)
 	};
 }
 
-Gdk::Color HyperRAMWaveform::GetColor(size_t i)
+std::string HyperRAMWaveform::GetColor(size_t i)
 {
 	const HyperRAMSymbol& s = m_samples[i];
 	switch(s.m_stype)

--- a/scopeprotocols/HyperRAMDecoder.h
+++ b/scopeprotocols/HyperRAMDecoder.h
@@ -71,7 +71,7 @@ class HyperRAMWaveform : public SparseWaveform<HyperRAMSymbol>
 public:
 	HyperRAMWaveform () : SparseWaveform<HyperRAMSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class HyperRAMDecoder : public Filter

--- a/scopeprotocols/I2CDecoder.cpp
+++ b/scopeprotocols/I2CDecoder.cpp
@@ -241,7 +241,7 @@ void I2CDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color I2CWaveform::GetColor(size_t i)
+std::string I2CWaveform::GetColor(size_t i)
 {
 	const I2CSymbol& s = m_samples[i];
 

--- a/scopeprotocols/I2CDecoder.h
+++ b/scopeprotocols/I2CDecoder.h
@@ -73,7 +73,7 @@ class I2CWaveform : public SparseWaveform<I2CSymbol>
 public:
 	I2CWaveform () : SparseWaveform<I2CSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class I2CDecoder : public Filter

--- a/scopeprotocols/I2CEepromDecoder.cpp
+++ b/scopeprotocols/I2CEepromDecoder.cpp
@@ -503,7 +503,7 @@ void I2CEepromDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color I2CEepromWaveform::GetColor(size_t i)
+std::string I2CEepromWaveform::GetColor(size_t i)
 {
 	const I2CEepromSymbol& s = m_samples[i];
 

--- a/scopeprotocols/I2CEepromDecoder.h
+++ b/scopeprotocols/I2CEepromDecoder.h
@@ -73,7 +73,7 @@ class I2CEepromWaveform : public SparseWaveform<I2CEepromSymbol>
 public:
 	I2CEepromWaveform (FilterParameter& raw_bits) : SparseWaveform<I2CEepromSymbol>(), m_raw_bits(raw_bits) {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 
 private:
 	FilterParameter& m_raw_bits;

--- a/scopeprotocols/IBM8b10bDecoder.cpp
+++ b/scopeprotocols/IBM8b10bDecoder.cpp
@@ -376,7 +376,7 @@ void IBM8b10bDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color IBM8b10bWaveform::GetColor(size_t i)
+std::string IBM8b10bWaveform::GetColor(size_t i)
 {
 	const IBM8b10bSymbol& s = m_samples[i];
 

--- a/scopeprotocols/IBM8b10bDecoder.h
+++ b/scopeprotocols/IBM8b10bDecoder.h
@@ -68,7 +68,7 @@ class IBM8b10bWaveform : public SparseWaveform<IBM8b10bSymbol>
 public:
 	IBM8b10bWaveform (FilterParameter& displayformat) : SparseWaveform<IBM8b10bSymbol>(), m_displayformat(displayformat) {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 
 	FilterParameter& m_displayformat;
 };

--- a/scopeprotocols/IPv4Decoder.cpp
+++ b/scopeprotocols/IPv4Decoder.cpp
@@ -405,7 +405,7 @@ void IPv4Decoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color IPv4Waveform::GetColor(size_t i)
+std::string IPv4Waveform::GetColor(size_t i)
 {
 	switch(m_samples[i].m_type)
 	{

--- a/scopeprotocols/IPv4Decoder.h
+++ b/scopeprotocols/IPv4Decoder.h
@@ -78,7 +78,7 @@ class IPv4Waveform : public SparseWaveform<IPv4Symbol>
 public:
 	IPv4Waveform () : SparseWaveform<IPv4Symbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class IPv4Decoder : public Filter

--- a/scopeprotocols/JtagDecoder.cpp
+++ b/scopeprotocols/JtagDecoder.cpp
@@ -333,7 +333,7 @@ void JtagDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color JtagWaveform::GetColor(size_t i)
+std::string JtagWaveform::GetColor(size_t i)
 {
 	const JtagSymbol& s = m_samples[i];
 

--- a/scopeprotocols/JtagDecoder.h
+++ b/scopeprotocols/JtagDecoder.h
@@ -99,7 +99,7 @@ class JtagWaveform : public SparseWaveform<JtagSymbol>
 public:
 	JtagWaveform () : SparseWaveform<JtagSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class JtagDecoder : public PacketDecoder

--- a/scopeprotocols/MDIODecoder.cpp
+++ b/scopeprotocols/MDIODecoder.cpp
@@ -623,7 +623,7 @@ vector<string> MDIODecoder::GetHeaders()
 	return ret;
 }
 
-Gdk::Color MDIOWaveform::GetColor(size_t i)
+std::string MDIOWaveform::GetColor(size_t i)
 {
 	const MDIOSymbol& s = m_samples[i];
 

--- a/scopeprotocols/MDIODecoder.h
+++ b/scopeprotocols/MDIODecoder.h
@@ -75,7 +75,7 @@ class MDIOWaveform : public SparseWaveform<MDIOSymbol>
 public:
 	MDIOWaveform () : SparseWaveform<MDIOSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class MDIODecoder : public PacketDecoder

--- a/scopeprotocols/MilStd1553Decoder.cpp
+++ b/scopeprotocols/MilStd1553Decoder.cpp
@@ -680,7 +680,7 @@ void MilStd1553Decoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color MilStd1553Waveform::GetColor(size_t i)
+std::string MilStd1553Waveform::GetColor(size_t i)
 {
 	const MilStd1553Symbol& s = m_samples[i];
 	switch(s.m_stype)

--- a/scopeprotocols/MilStd1553Decoder.h
+++ b/scopeprotocols/MilStd1553Decoder.h
@@ -97,7 +97,7 @@ class MilStd1553Waveform : public SparseWaveform<MilStd1553Symbol>
 public:
 	MilStd1553Waveform () : SparseWaveform<MilStd1553Symbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class MilStd1553Decoder : public PacketDecoder

--- a/scopeprotocols/OneWireDecoder.cpp
+++ b/scopeprotocols/OneWireDecoder.cpp
@@ -275,7 +275,7 @@ void OneWireDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color OneWireWaveform::GetColor(size_t i)
+std::string OneWireWaveform::GetColor(size_t i)
 {
 	const OneWireSymbol& s = m_samples[i];
 

--- a/scopeprotocols/OneWireDecoder.h
+++ b/scopeprotocols/OneWireDecoder.h
@@ -69,7 +69,7 @@ class OneWireWaveform : public SparseWaveform<OneWireSymbol>
 public:
 	OneWireWaveform () : SparseWaveform<OneWireSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class OneWireDecoder : public Filter

--- a/scopeprotocols/PCIe128b130bDecoder.cpp
+++ b/scopeprotocols/PCIe128b130bDecoder.cpp
@@ -221,7 +221,7 @@ void PCIe128b130bDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color PCIe128b130bWaveform::GetColor(size_t i)
+std::string PCIe128b130bWaveform::GetColor(size_t i)
 {
 	const PCIe128b130bSymbol& s = m_samples[i];
 

--- a/scopeprotocols/PCIe128b130bDecoder.h
+++ b/scopeprotocols/PCIe128b130bDecoder.h
@@ -73,7 +73,7 @@ class PCIe128b130bWaveform : public SparseWaveform<PCIe128b130bSymbol>
 public:
 	PCIe128b130bWaveform () : SparseWaveform<PCIe128b130bSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class PCIe128b130bDecoder : public Filter

--- a/scopeprotocols/PCIeDataLinkDecoder.cpp
+++ b/scopeprotocols/PCIeDataLinkDecoder.cpp
@@ -671,7 +671,7 @@ uint32_t PCIeDataLinkDecoder::CalculateTlpCRC(Packet* pack)
 		return CRC32(&pack->m_data[0], 0, len - 1);
 }
 
-Gdk::Color PCIeDataLinkWaveform::GetColor(size_t i)
+std::string PCIeDataLinkWaveform::GetColor(size_t i)
 {
 	auto s = m_samples[i];
 

--- a/scopeprotocols/PCIeDataLinkDecoder.h
+++ b/scopeprotocols/PCIeDataLinkDecoder.h
@@ -107,7 +107,7 @@ class PCIeDataLinkWaveform : public SparseWaveform<PCIeDataLinkSymbol>
 public:
 	PCIeDataLinkWaveform () : SparseWaveform<PCIeDataLinkSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 /**

--- a/scopeprotocols/PCIeGen2LogicalDecoder.cpp
+++ b/scopeprotocols/PCIeGen2LogicalDecoder.cpp
@@ -344,7 +344,7 @@ uint8_t PCIeGen2LogicalDecoder::RunScrambler(uint16_t& state)
 	return ret;
 }
 
-Gdk::Color PCIeLogicalWaveform::GetColor(size_t i)
+std::string PCIeLogicalWaveform::GetColor(size_t i)
 {
 	const PCIeLogicalSymbol& s = m_samples[i];
 

--- a/scopeprotocols/PCIeGen2LogicalDecoder.h
+++ b/scopeprotocols/PCIeGen2LogicalDecoder.h
@@ -76,7 +76,7 @@ class PCIeLogicalWaveform : public SparseWaveform<PCIeLogicalSymbol>
 public:
 	PCIeLogicalWaveform () : SparseWaveform<PCIeLogicalSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 /**

--- a/scopeprotocols/PCIeTransportDecoder.cpp
+++ b/scopeprotocols/PCIeTransportDecoder.cpp
@@ -911,7 +911,7 @@ void PCIeTransportDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color PCIeTransportWaveform::GetColor(size_t i)
+std::string PCIeTransportWaveform::GetColor(size_t i)
 {
 	auto s = m_samples[i];
 

--- a/scopeprotocols/PCIeTransportDecoder.h
+++ b/scopeprotocols/PCIeTransportDecoder.h
@@ -115,7 +115,7 @@ class PCIeTransportWaveform : public SparseWaveform<PCIeTransportSymbol>
 public:
 	PCIeTransportWaveform () : SparseWaveform<PCIeTransportSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 /**

--- a/scopeprotocols/SDCmdDecoder.cpp
+++ b/scopeprotocols/SDCmdDecoder.cpp
@@ -381,7 +381,7 @@ bool SDCmdDecoder::GetShowDataColumn()
 	return false;
 }
 
-Gdk::Color SDCmdWaveform::GetColor(size_t i)
+std::string SDCmdWaveform::GetColor(size_t i)
 {
 	auto s = m_samples[i];
 	switch(s.m_stype)

--- a/scopeprotocols/SDCmdDecoder.h
+++ b/scopeprotocols/SDCmdDecoder.h
@@ -84,7 +84,7 @@ class SDCmdWaveform : public SparseWaveform<SDCmdSymbol>
 public:
 	SDCmdWaveform (FilterParameter& cardTypeParam) : SparseWaveform<SDCmdSymbol>(), m_cardTypeParam(cardTypeParam) {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 
 	FilterParameter& m_cardTypeParam;
 };

--- a/scopeprotocols/SDDataDecoder.cpp
+++ b/scopeprotocols/SDDataDecoder.cpp
@@ -261,7 +261,7 @@ void SDDataDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color SDDataWaveform::GetColor(size_t i)
+std::string SDDataWaveform::GetColor(size_t i)
 {
 	const SDDataSymbol& s = m_samples[i];
 	switch(s.m_stype)

--- a/scopeprotocols/SDDataDecoder.h
+++ b/scopeprotocols/SDDataDecoder.h
@@ -74,7 +74,7 @@ class SDDataWaveform : public SparseWaveform<SDDataSymbol>
 public:
 	SDDataWaveform () : SparseWaveform<SDDataSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class SDDataDecoder : public PacketDecoder

--- a/scopeprotocols/SDRAMDecoderBase.cpp
+++ b/scopeprotocols/SDRAMDecoderBase.cpp
@@ -49,7 +49,7 @@ SDRAMDecoderBase::~SDRAMDecoderBase()
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Pretty printing
 
-Gdk::Color SDRAMWaveform::GetColor(size_t i)
+std::string SDRAMWaveform::GetColor(size_t i)
 {
 	const SDRAMSymbol& s = m_samples[i];
 

--- a/scopeprotocols/SDRAMDecoderBase.h
+++ b/scopeprotocols/SDRAMDecoderBase.h
@@ -76,7 +76,7 @@ class SDRAMWaveform : public SparseWaveform<SDRAMSymbol>
 public:
 	SDRAMWaveform () : SparseWaveform<SDRAMSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class SDRAMDecoderBase : public Filter

--- a/scopeprotocols/SPIDecoder.cpp
+++ b/scopeprotocols/SPIDecoder.cpp
@@ -262,7 +262,7 @@ void SPIDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color SPIWaveform::GetColor(size_t i)
+std::string SPIWaveform::GetColor(size_t i)
 {
 	const SPISymbol& s = m_samples[i];
 	switch(s.m_stype)

--- a/scopeprotocols/SPIDecoder.h
+++ b/scopeprotocols/SPIDecoder.h
@@ -69,7 +69,7 @@ class SPIWaveform : public SparseWaveform<SPISymbol>
 public:
 	SPIWaveform () : SparseWaveform<SPISymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class SPIDecoder : public Filter

--- a/scopeprotocols/SPIFlashDecoder.cpp
+++ b/scopeprotocols/SPIFlashDecoder.cpp
@@ -1008,7 +1008,7 @@ void SPIFlashDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color SPIFlashWaveform::GetColor(size_t i)
+std::string SPIFlashWaveform::GetColor(size_t i)
 {
 	const SPIFlashSymbol& s = m_samples[i];
 

--- a/scopeprotocols/SPIFlashDecoder.h
+++ b/scopeprotocols/SPIFlashDecoder.h
@@ -116,7 +116,7 @@ class SPIFlashWaveform : public SparseWaveform<SPIFlashSymbol>
 public:
 	SPIFlashWaveform () : SparseWaveform<SPIFlashSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class SPIFlashDecoder : public PacketDecoder

--- a/scopeprotocols/SWDDecoder.cpp
+++ b/scopeprotocols/SWDDecoder.cpp
@@ -440,7 +440,7 @@ void SWDDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color SWDWaveform::GetColor(size_t i)
+std::string SWDWaveform::GetColor(size_t i)
 {
 	const SWDSymbol& s = m_samples[i];
 

--- a/scopeprotocols/SWDDecoder.h
+++ b/scopeprotocols/SWDDecoder.h
@@ -75,7 +75,7 @@ class SWDWaveform : public SparseWaveform<SWDSymbol>
 public:
 	SWDWaveform () : SparseWaveform<SWDSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class SWDDecoder : public Filter

--- a/scopeprotocols/SWDMemAPDecoder.cpp
+++ b/scopeprotocols/SWDMemAPDecoder.cpp
@@ -342,7 +342,7 @@ void SWDMemAPDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color SWDMemAPWaveform::GetColor(size_t /*i*/)
+std::string SWDMemAPWaveform::GetColor(size_t /*i*/)
 {
 	return StandardColors::colors[StandardColors::COLOR_DATA];
 }

--- a/scopeprotocols/SWDMemAPDecoder.h
+++ b/scopeprotocols/SWDMemAPDecoder.h
@@ -65,7 +65,7 @@ class SWDMemAPWaveform : public SparseWaveform<SWDMemAPSymbol>
 public:
 	SWDMemAPWaveform () : SparseWaveform<SWDMemAPSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class SWDMemAPDecoder : public PacketDecoder

--- a/scopeprotocols/TCPDecoder.cpp
+++ b/scopeprotocols/TCPDecoder.cpp
@@ -395,7 +395,7 @@ void TCPDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color TCPWaveform::GetColor(size_t i)
+std::string TCPWaveform::GetColor(size_t i)
 {
 	switch(m_samples[i].m_type)
 	{

--- a/scopeprotocols/TCPDecoder.h
+++ b/scopeprotocols/TCPDecoder.h
@@ -77,7 +77,7 @@ class TCPWaveform : public SparseWaveform<TCPSymbol>
 public:
 	TCPWaveform () : SparseWaveform<TCPSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class TCPDecoder : public Filter

--- a/scopeprotocols/TMDSDecoder.cpp
+++ b/scopeprotocols/TMDSDecoder.cpp
@@ -251,7 +251,7 @@ void TMDSDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color TMDSWaveform::GetColor(size_t i)
+std::string TMDSWaveform::GetColor(size_t i)
 {
 	const TMDSSymbol& s = m_samples[i];
 

--- a/scopeprotocols/TMDSDecoder.h
+++ b/scopeprotocols/TMDSDecoder.h
@@ -70,7 +70,7 @@ class TMDSWaveform : public SparseWaveform<TMDSSymbol>
 public:
 	TMDSWaveform () : SparseWaveform<TMDSSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class TMDSDecoder : public Filter

--- a/scopeprotocols/UARTDecoder.cpp
+++ b/scopeprotocols/UARTDecoder.cpp
@@ -228,9 +228,9 @@ void UARTDecoder::FinishPacket(Packet* pack)
 	m_packets.push_back(pack);
 }
 
-Gdk::Color ByteWaveform::GetColor(size_t /*i*/)
+std::string ByteWaveform::GetColor(size_t /*i*/)
 {
-	return Gdk::Color(m_color);
+	return m_color;
 }
 
 string ByteWaveform::GetText(size_t i)

--- a/scopeprotocols/UARTDecoder.h
+++ b/scopeprotocols/UARTDecoder.h
@@ -43,7 +43,7 @@ class ByteWaveform : public SparseWaveform<char>
 public:
 	ByteWaveform (const std::string& color) : SparseWaveform<char>(), m_color(color) {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 
 private:
 	const std::string& m_color;

--- a/scopeprotocols/USB2PCSDecoder.cpp
+++ b/scopeprotocols/USB2PCSDecoder.cpp
@@ -505,7 +505,7 @@ void USB2PCSDecoder::RefreshIterationData(
 	}
 }
 
-Gdk::Color USB2PCSWaveform::GetColor(size_t i)
+std::string USB2PCSWaveform::GetColor(size_t i)
 {
 	auto sample = m_samples[i];
 	switch(sample.m_type)

--- a/scopeprotocols/USB2PCSDecoder.h
+++ b/scopeprotocols/USB2PCSDecoder.h
@@ -75,7 +75,7 @@ class USB2PCSWaveform : public SparseWaveform<USB2PCSSymbol>
 public:
 	USB2PCSWaveform () : SparseWaveform<USB2PCSSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class USB2PCSDecoder : public Filter

--- a/scopeprotocols/USB2PMADecoder.cpp
+++ b/scopeprotocols/USB2PMADecoder.cpp
@@ -200,7 +200,7 @@ void USB2PMADecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color USB2PMAWaveform::GetColor(size_t i)
+std::string USB2PMAWaveform::GetColor(size_t i)
 {
 	auto sample = m_samples[i];
 	switch(sample.m_type)

--- a/scopeprotocols/USB2PMADecoder.h
+++ b/scopeprotocols/USB2PMADecoder.h
@@ -68,7 +68,7 @@ class USB2PMAWaveform : public SparseWaveform<USB2PMASymbol>
 public:
 	USB2PMAWaveform () : SparseWaveform<USB2PMASymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class USB2PMADecoder : public Filter

--- a/scopeprotocols/USB2PacketDecoder.cpp
+++ b/scopeprotocols/USB2PacketDecoder.cpp
@@ -815,7 +815,7 @@ void USB2PacketDecoder::DecodeData(USB2PacketWaveform* cap, size_t istart, size_
 	m_packets.push_back(pack);
 }
 
-Gdk::Color USB2PacketWaveform::GetColor(size_t i)
+std::string USB2PacketWaveform::GetColor(size_t i)
 {
 	auto sample = m_samples[i];
 	switch(sample.m_type)

--- a/scopeprotocols/USB2PacketDecoder.h
+++ b/scopeprotocols/USB2PacketDecoder.h
@@ -100,7 +100,7 @@ class USB2PacketWaveform : public SparseWaveform<USB2PacketSymbol>
 public:
 	USB2PacketWaveform () : SparseWaveform<USB2PacketSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class USB2PacketDecoder : public PacketDecoder

--- a/scopeprotocols/VICPDecoder.cpp
+++ b/scopeprotocols/VICPDecoder.cpp
@@ -478,7 +478,7 @@ void VICPDecoder::Refresh()
 	cap->MarkModifiedFromCpu();
 }
 
-Gdk::Color VICPWaveform::GetColor(size_t i)
+std::string VICPWaveform::GetColor(size_t i)
 {
 	const VICPSymbol& s = m_samples[i];
 

--- a/scopeprotocols/VICPDecoder.h
+++ b/scopeprotocols/VICPDecoder.h
@@ -78,7 +78,7 @@ class VICPWaveform : public SparseWaveform<VICPSymbol>
 public:
 	VICPWaveform () : SparseWaveform<VICPSymbol>() {};
 	virtual std::string GetText(size_t) override;
-	virtual Gdk::Color GetColor(size_t) override;
+	virtual std::string GetColor(size_t) override;
 };
 
 class VICPDecoder : public PacketDecoder


### PR DESCRIPTION
This PR accomplishes two things to further the goal of being able to build `ngscopeclient` without a GTK dependency:
1. Replaces all uses of `Gdk::Color` in scopehal with `std::string`
2. Moves GTK-containing export wizards from `scopehal` to `scopeexports`

`scopehal` itself should now be free of GTK references, though `scopeprotocols` still uses `cairomm` for software rendering of eye diagrams.