### PR TITLE
Remove usage of posix APIs

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -57,7 +57,6 @@ set(SCOPEHAL_SOURCES
 	SCPILinuxGPIBTransport.cpp
 	SCPILxiTransport.cpp
 	SCPINullTransport.cpp
-	SCPITMCTransport.cpp
 	SCPIUARTTransport.cpp
 	SCPIDevice.cpp
 
@@ -135,6 +134,14 @@ set(SCOPEHAL_SOURCES
 	PipelineCacheManager.cpp
 	VulkanFFTPlan.cpp
 	)
+
+if(NOT WIN32 AND NOT APPLE)
+	list(APPEND SCOPEHAL_SOURCES
+		# TMC is only supported on Linux for now.
+		# https://github.com/glscopeclient/scopehal/issues/519
+		SCPITMCTransport.cpp
+	)
+endif()
 
 configure_file(config.h.in config.h)
 

--- a/scopehal/Oscilloscope.cpp
+++ b/scopehal/Oscilloscope.cpp
@@ -37,10 +37,6 @@
 #include "OscilloscopeChannel.h"
 
 #include <stdio.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/types.h>
-#include <dirent.h>
 
 #ifdef __x86_64__
 #include <immintrin.h>

--- a/scopehal/SCPINullTransport.cpp
+++ b/scopehal/SCPINullTransport.cpp
@@ -36,8 +36,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <fcntl.h>
-#include <unistd.h>
 
 #include "scopehal.h"
 

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -111,7 +111,11 @@ void VulkanCleanup();
 void TransportStaticInit()
 {
 	AddTransportClass(SCPISocketTransport);
+#if !defined(_WIN32) && !defined(__APPLE__)
+// TMC is only supported on Linux for now
+// https://github.com/glscopeclient/scopehal/issues/519
 	AddTransportClass(SCPITMCTransport);
+#endif
 	AddTransportClass(SCPITwinLanTransport);
 	AddTransportClass(SCPIUARTTransport);
 	AddTransportClass(SCPINullTransport);

--- a/scopehal/scopehal.h
+++ b/scopehal/scopehal.h
@@ -88,10 +88,15 @@ extern bool g_hasAvx2;
 #include "SCPILinuxGPIBTransport.h"
 #include "SCPILxiTransport.h"
 #include "SCPINullTransport.h"
-#include "SCPITMCTransport.h"
 #include "SCPIUARTTransport.h"
 #include "VICPSocketTransport.h"
 #include "SCPIDevice.h"
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+// TMC is only supported on Linux for now
+// https://github.com/glscopeclient/scopehal/issues/519
+#include "SCPITMCTransport.h"
+#endif
 
 #include "FlowGraphNode.h"
 #include "OscilloscopeChannel.h"


### PR DESCRIPTION
This PR cleans up all unconditional uses of POSIX APIs I found in the repository, and along with a small additional PR to follow in glscopeclient/scopehal-apps, will close https://github.com/glscopeclient/scopehal/issues/711.