### PR TITLE
Fix waveform drawing for the AgilentOscilloscope driver

### DIFF
--- a/scopehal/AgilentOscilloscope.cpp
+++ b/scopehal/AgilentOscilloscope.cpp
@@ -666,8 +666,9 @@ bool AgilentOscilloscope::AcquireData()
 		if(preamble.length != buf.size())
 			LogError("Waveform preamble length (%lu) does not match data length (%lu)", preamble.length, buf.size());
 		cap->Resize(buf.size());
-		for(size_t j = 0; j < buf.size(); j++)
-			cap->m_samples[j] = preamble.yincrement * (buf[j] - preamble.yreference) + preamble.yorigin;
+		float gain = preamble.yincrement;
+		float offset = (gain * preamble.yreference) - preamble.yorigin;
+		ConvertUnsigned8BitSamples(cap->m_samples.GetCpuPointer(), buf.data(), gain, offset, buf.size());
 
 		//Done, update the data
 		cap->MarkSamplesModifiedFromCpu();

--- a/scopehal/AgilentOscilloscope.cpp
+++ b/scopehal/AgilentOscilloscope.cpp
@@ -670,6 +670,7 @@ bool AgilentOscilloscope::AcquireData()
 			cap->m_samples[j] = preamble.yincrement * (buf[j] - preamble.yreference) + preamble.yorigin;
 
 		//Done, update the data
+		cap->MarkSamplesModifiedFromCpu();
 		pending_waveforms[i].push_back(cap);
 	}
 


### PR DESCRIPTION
This adds a missing `MarkSamplesModifiedFromCpu` call to the AgilentOscilloscope driver, that was preventing waveforms from being drawn.
I also made it use `ConvertUnsigned8BitSamples`, while I was making changes :)