### PR TITLE
USB2PacketDecoder: fix DecodeSetup behaviour when the ACK/NAK packet is missing

### DIFF
--- a/scopeprotocols/USB2PacketDecoder.cpp
+++ b/scopeprotocols/USB2PacketDecoder.cpp
@@ -546,13 +546,19 @@ void USB2PacketDecoder::DecodeSetup(USB2PacketWaveform* cap, size_t istart, size
 		LogDebug("Truncated ACK\n");
 		return;
 	}
-	auto sack = cap->m_samples[i++];
+	auto sack = cap->m_samples[i];
 	if(sack.m_type == USB2PacketSymbol::TYPE_PID)
 	{
 		if( (sack.m_data & 0xf) == USB2PacketSymbol::PID_ACK)
+		{
 			ack = "ACK";
+			i++;
+		}
 		else if( (sack.m_data & 0xf) == USB2PacketSymbol::PID_NAK)
+		{
 			ack = "NAK";
+			i++;
+		}
 		else
 			ack = "Unknown end PID";
 	}


### PR DESCRIPTION
Previously, when looking for a response to a setup packet, DecodeSetup would consume the subsequent packet whether it was an ACK/NACK or not.

In cases where the device did not reply, the decoder would consume a packet from the next transaction and break the decoding.

This commit makes sure that DecodeSetup only consumes the subsequent packet iff it is an ACK or NAK.

fixes #723