### PR TITLE
RMII Decoder - wait for preamble before decoding for PHYs with leading CTL (LAN8270)

### DIFF
--- a/scopeprotocols/EthernetRMIIDecoder.cpp
+++ b/scopeprotocols/EthernetRMIIDecoder.cpp
@@ -123,6 +123,10 @@ void EthernetRMIIDecoder::Refresh()
 		if(!dctl.m_samples[i])
 			continue;
 
+		//No preamble (ctl high, d0 high, d1 low) yet
+		if(!dd0.m_samples[i])
+			continue;
+
 		//Set of recovered bytes and timestamps
 		vector<uint8_t> bytes;
 		vector<uint64_t> starts;


### PR DESCRIPTION
Tested on a LA waveform from an MSO5074. Without preamble wait analysis hangs.