### PR TITLE
Fix for #652

### DIFF
--- a/scopehal/SCPITMCTransport.h
+++ b/scopehal/SCPITMCTransport.h
@@ -59,6 +59,8 @@ public:
 	virtual bool IsCommandBatchingSupported();
 	virtual bool IsConnected();
 
+	virtual void FlushRXBuffer(void);
+
 	TRANSPORT_INITPROC(SCPITMCTransport)
 
 	const std::string& GetDevicePath()
@@ -75,6 +77,8 @@ protected:
 	int m_data_in_staging_buf;
 	int m_data_offset;
 	bool m_data_depleted;
+	bool m_fix_buggy_driver;
+	int m_transfer_size;
 };
 
 #endif

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -294,7 +294,7 @@ void SiglentSCPIOscilloscope::IdentifyHardware()
 			m_maxBandwidth = 100;
 			if(m_model.compare(4, 1, "2") == 0)
 				m_maxBandwidth = 200;
-			if(m_fwVersion != "8.2.6.1.37R8")
+			if(m_fwVersion != "8.2.6.1.37R9")
 				LogWarning("Siglent firmware \"%s\" is not tested\n", m_fwVersion.c_str());
 			return;
 		}


### PR DESCRIPTION
We can configure the USBTMC transfer size
for example: opening /dev/ubtmc0 with transfer size 48 /dev/usbtmc0:48

glscopeclient myscope:siglent:usbtmc:/dev/usbtmc0:48

Workaround for Siglent SDS1x04X-E. Max request size is 48 byte. Bug in firmware 8.2.6.1.37R9 ?