### PR TITLE
SCPITMCTransport: fix usbtmc reads if driver workaround is not present

### DIFF
--- a/scopehal/SCPITMCTransport.cpp
+++ b/scopehal/SCPITMCTransport.cpp
@@ -200,6 +200,7 @@ size_t SCPITMCTransport::ReadRawData(size_t len, unsigned char* buf)
 				    bytes_requested = (max_bytes_per_req < len) ? max_bytes_per_req : len;
 				    bytes_fetched = read(m_handle, (char *)m_staging_buf + i, m_staging_buf_size);
 				}
+				else
 				{
 					// limit each request to m_transfer_size
 					bytes_requested = m_transfer_size;


### PR DESCRIPTION
Just a missing `else`. 
Rigol DS1054Z still doesn't work like this properly, but that's hopefully a different issue.

Before:
```
[stary@glados build]$ ./src/glscopeclient/glscopeclient rigol:rigol:usbtmc:/dev/usbtmc0
Warning: Bad IDN response  
Warning: Bad IDN response  
Warning: Bad IDN response  
ERROR: Persistent bad IDN response, giving up
ERROR: Bad model number
Segmentation fault (core dumped)
```

After: 
No errors.