### PR TITLE
Fix memory leak when reallocating output buffer for autosized histogram

### DIFF
--- a/scopeprotocols/HistogramFilter.cpp
+++ b/scopeprotocols/HistogramFilter.cpp
@@ -212,6 +212,9 @@ void HistogramFilter::Refresh()
 	//Reallocate the histogram if we changed it
 	if(reallocate)
 	{
+		if (cap)
+			delete cap;
+		
 		//Reallocate our waveform
 		cap = new UniformAnalogWaveform;
 		cap->m_timescale = binsize;


### PR DESCRIPTION
Not exciting, just an oversight. Slow leak in normal operation, but annoying.