### PR TITLE
USB2PMADecoder: Adjust high speed threshold level

### DIFF
--- a/scopeprotocols/USB2PMADecoder.cpp
+++ b/scopeprotocols/USB2PMADecoder.cpp
@@ -102,7 +102,7 @@ void USB2PMADecoder::Refresh()
 	auto speed = static_cast<Speed>(m_parameters[m_speedname].GetIntVal());
 
 	//Set appropriate thresholds for different speeds
-	auto threshold = (speed == SPEED_HIGH) ? 0.2 : 0.4;
+	auto threshold = (speed == SPEED_HIGH) ? 0.15 : 0.4;
 	int64_t transition_time;
 	switch(speed)
 	{


### PR DESCRIPTION
USB 2.0 - 7.1.7.2 - Table 7-3 states that "receiver must not indicate squelch if magnitude of differential voltage is ≥150 mV".

Also in the receiver sensitivity section, some of the eye templates show "must decode" eyes as low as 150 mW in some cases.