### PR TITLE
USB2PMADecoder: Use different threshold for Differential and Single Ended

### DIFF
--- a/scopeprotocols/USB2PMADecoder.cpp
+++ b/scopeprotocols/USB2PMADecoder.cpp
@@ -102,7 +102,8 @@ void USB2PMADecoder::Refresh()
 	auto speed = static_cast<Speed>(m_parameters[m_speedname].GetIntVal());
 
 	//Set appropriate thresholds for different speeds
-	auto threshold = (speed == SPEED_HIGH) ? 0.15 : 0.4;
+	auto threshold_diff = (speed == SPEED_HIGH) ? 0.15 : 0.2;
+	auto threshold_se   = 0.8;
 	int64_t transition_time;
 	switch(speed)
 	{
@@ -127,12 +128,12 @@ void USB2PMADecoder::Refresh()
 	{
 		auto vp = GetValue(sdin_p, udin_p, i);
 		auto vn = GetValue(sdin_n, udin_n, i);
-		bool bp = (vp > threshold);
-		bool bn = (vn > threshold);
+		bool bp = (vp > threshold_se);
+		bool bn = (vn > threshold_se);
 		float vdiff = vp - vn;
 
 		USB2PMASymbol::SegmentType type = USB2PMASymbol::TYPE_SE1;
-		if(fabs(vdiff) > threshold)
+		if(fabs(vdiff) > threshold_diff)
 		{
 			if( (speed == SPEED_FULL) || (speed == SPEED_HIGH) )
 			{


### PR DESCRIPTION
The threshold to use to see if we have a valid differential signals (DP - DN) is different from the one to use to see if we're in SE00 or SE11.

- For LS/FS USB 2.0 -  7.1.71 - Table 7-2 States that 200 mV differential is enough and that SE1 requires both lines to be above Vil

- For HS USB 2.0 - 7.1.7.2 - Table 7-3 States that 150 mV differential is enough

- USB 2.0 - 7.3.2 - Tables 7-7 Gives Vil = 0.8V