### PR TITLE
Update scopehal.cpp FindDataFile to use relative path when possible

### DIFF
--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -767,6 +767,12 @@ vector<uint32_t> ReadDataFileUint32(const string& relpath)
  */
 string FindDataFile(const string& relpath)
 {
+	FILE* fp = fopen(relpath.c_str(), "rb");
+	if(fp)
+	{
+		fclose(fp);
+		return relpath;
+	}
 	for(auto dir : g_searchPaths)
 	{
 		string path = dir + "/" + relpath;


### PR DESCRIPTION
Fix issue https://github.com/glscopeclient/scopehal-apps/issues/596
Potentially the same fix shall be done also for those API
https://github.com/glscopeclient/scopehal/blob/master/scopehal/scopehal.cpp
- ReadDataFile()
- ReadDataFileUint32()

To be discussed