### PR TITLE
Add Siglent GlitchTrigger support

### DIFF
--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -3618,7 +3618,7 @@ void SiglentSCPIOscilloscope::PullGlitchTrigger()
 		case MODEL_SIGLENT_SDS1000:
 		case MODEL_SIGLENT_SDS2000XE:
 			reply = Trim(converse("TRIG_SELECT?"));
-			// TRSE GLIT,SR,<source>,HT,<hold_type>,HV,<hold_value1>[,HV2,<hold_value2>]
+			// GLIT,SR,<source>,HT,<hold_type>,HV,<hold_value1>[,HV2,<hold_value2>]
 			// <hold_type> := (PS|PL|P2|P1)
 			// PS := Less than
 			// PL := Greater than
@@ -3629,16 +3629,15 @@ void SiglentSCPIOscilloscope::PullGlitchTrigger()
 				char hold_type[128] = "";
 				char hold_value1[128] = "";
 				char hold_value2[128] = "";
-				if(3 > sscanf(reply.c_str(), "TRSE GLIT,SR,%127[^,],HT,%127[^,],HV,%127[^,],HV2,%127s", source, hold_type, hold_value1, hold_value2))
+				if(3 > sscanf(reply.c_str(), "GLIT,SR,%127[^,],HT,%127[^,],HV,%127[^,],HV2,%127s", source, hold_type, hold_value1, hold_value2))
 				{
 					LogError("Bad TRSE response %s\n", reply.c_str());
 					break;
 				}
 
 				//Level
-				// <trig_source>:TRLV <trig_level>V
 				Unit v(Unit::UNIT_VOLTS);
-				gt->SetLevel(v.ParseString(converse("C1:TRIG_LEVEL?").substr(8)));
+				gt->SetLevel(v.ParseString(converse("C1:TRIG_LEVEL?")));
 
 				//Condition
 				Trigger::Condition condition = GetCondition(hold_type);
@@ -3666,8 +3665,7 @@ void SiglentSCPIOscilloscope::PullGlitchTrigger()
 				}
 
 				//Slope
-				// <trig_source>:TRSL <trig_slope>
-				GetTriggerSlope(gt, converse("C1:TRIG_SLOPE?").substr(8));
+				GetTriggerSlope(gt, converse("C1:TRIG_SLOPE?"));
 			}
 			break;
 		// --------------------------------------------------

--- a/scopehal/SiglentSCPIOscilloscope.h
+++ b/scopehal/SiglentSCPIOscilloscope.h
@@ -222,6 +222,7 @@ public:
 protected:
 	void PullDropoutTrigger();
 	void PullEdgeTrigger();
+	void PullGlitchTrigger();
 	void PullPulseWidthTrigger();
 	void PullRuntTrigger();
 	void PullSlewRateTrigger();


### PR DESCRIPTION
This adds Glitch/Pulse trigger support for several Siglent Oscilloscopes.

Although tested only with SDS2000X Plus, this should support SDS1000, SDS2000X-E, SDS2000X Plus, SDS2000X HD, SDS5000X, SDS6000A.

For reference, SDS2000X Plus supports TRIG_SELECT and :TRIGGER:PULSE command formats. The TRIG_SELECT compatibility allowed me to add/test support for SDS1000 despite not owning one. Even so, it would be nice if someone could test this with different models.

Looking at #778, I am having doubts whether I should define Glitch/Pulse trigger under GlitchTrigger or PulseWidthTrigger.
- On one hand, SDS2000X Plus reports "TRSE GLIT,..." when using the Pulse trigger.
    - This would support the idea of defining Pulse trigger as GlitchTrigger.
    - This would not conflict with Interval trigger being defined as PulseWidthTrigger.
- On the other hand, Pulse trigger best fits the description for triggering on pulse width compared to Interval trigger.
    - Interval trigger examines the positive edge to positive edge interval between two pulses (assuming positive polarity).
    - Glitch/Pulse trigger examines the width of a pulse from positive edge to negative edge (assuming positive polarity).
    - Glitch/Pulse example: Triggering on <80 ns pulse (looking at TMS of some JTAG device).
        - ![image](https://github.com/glscopeclient/scopehal/assets/40348686/5fe19ad7-d113-43e2-b99b-1e9e45e0845e)
    - Interval example: same example, but instead of looking at pulse width directly, I have to reference a neighboring edge
        - ![image](https://github.com/glscopeclient/scopehal/assets/40348686/33776336-d3ee-4657-829a-b6d091ee0603)