### PR TITLE
[Siglent SDS2000X Plus] Fix ADC mode setting; Fix slow 10-bit data acquisition with newer firmware

### DIFF
--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -3242,13 +3242,13 @@ size_t SiglentSCPIOscilloscope::GetADCMode(size_t /*channel*/)
 	{
 		m_adcMode = ADC_MODE_10BIT;
 		m_highDefinition = true;
-		m_transport->SendCommandQueuedWithReply(":WAVEFORM:WIDTH WORD");
+		m_transport->SendCommandQueued(":WAVEFORM:WIDTH WORD");
 	}
 	else //if(reply == "8Bits")
 	{
 		m_adcMode = ADC_MODE_8BIT;
 		m_highDefinition = false;
-		m_transport->SendCommandQueuedWithReply(":WAVEFORM:WIDTH BYTE");
+		m_transport->SendCommandQueued(":WAVEFORM:WIDTH BYTE");
 	}
 
 	return m_adcMode;
@@ -3278,12 +3278,12 @@ void SiglentSCPIOscilloscope::SetADCMode(size_t /*channel*/, size_t mode)
 	if(mode == ADC_MODE_10BIT)
 	{
 		m_transport->SendCommandQueued("ACQ:RES 10Bits");
-		m_transport->SendCommandQueuedWithReply(":WAVEFORM:WIDTH WORD");
+		m_transport->SendCommandQueued(":WAVEFORM:WIDTH WORD");
 	}
 	else //if(mode == ADC_MODE_8BIT)
 	{
 		m_transport->SendCommandQueued("ACQ:RES 8Bits");
-		m_transport->SendCommandQueuedWithReply(":WAVEFORM:WIDTH BYTE");
+		m_transport->SendCommandQueued(":WAVEFORM:WIDTH BYTE");
 	}
 
 	if(IsTriggerArmed())

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -98,6 +98,7 @@ static const struct
 } c_sds2000xp_threshold_table[] = {{"TTL", 1.5F}, {"CMOS", 1.65F}, {"LVCMOS33", 1.65F}, {"LVCMOS25", 1.25F}, {NULL, 0}};
 
 static const std::chrono::milliseconds c_trigger_delay(1000);	 // Delay required when forcing trigger
+static const std::chrono::milliseconds c_adc_delay(200);		 // Delay required when setting ADC mode
 static const char* c_custom_thresh = "CUSTOM,";					 // Prepend string for custom digital threshold
 static const float c_thresh_thresh = 0.01f;						 // Zero equivalence threshold for fp comparisons
 
@@ -3278,13 +3279,16 @@ void SiglentSCPIOscilloscope::SetADCMode(size_t /*channel*/, size_t mode)
 	if(mode == ADC_MODE_10BIT)
 	{
 		m_transport->SendCommandQueued("ACQ:RES 10Bits");
+		this_thread::sleep_for(c_adc_delay);
 		m_transport->SendCommandQueued(":WAVEFORM:WIDTH WORD");
 	}
 	else //if(mode == ADC_MODE_8BIT)
 	{
 		m_transport->SendCommandQueued("ACQ:RES 8Bits");
+		this_thread::sleep_for(c_adc_delay);
 		m_transport->SendCommandQueued(":WAVEFORM:WIDTH BYTE");
 	}
+	this_thread::sleep_for(c_adc_delay);
 
 	if(IsTriggerArmed())
 		m_transport->SendCommandQueued("TRIG_MODE SINGLE");

--- a/scopehal/SiglentSCPIOscilloscope.h
+++ b/scopehal/SiglentSCPIOscilloscope.h
@@ -288,6 +288,9 @@ protected:
 	bool m_hasSpiTrigger;
 	bool m_hasUartTrigger;
 
+	//SDS2000XP firmware <=1.3.6R6 has data size bug while in 10 bit mode
+	bool m_requireSizeWorkaround;
+
 	///Maximum bandwidth we support, in MHz
 	unsigned int m_maxBandwidth;
 


### PR DESCRIPTION
Fixes #784.


Tasks:
- [x] Add delays to set :WAV:WIDTH
- [x] Replace invalid queries on set commands
- [x] Skip data size workaround for firmware versions 1.3.9R10 and newer. 
    - I currently assume data size bug is present in versions 1.3.9R6 and older.
- [ ] Get confirmation that the size bug is or is not present in versions older than 1.3.9R6.
- [ ] Test from another SDS2000X Plus user.