### PR TITLE
Fix incorrect Vulkan queue type selection on some AMD GPUs

### DIFF
--- a/scopehal/QueueManager.cpp
+++ b/scopehal/QueueManager.cpp
@@ -180,7 +180,7 @@ shared_ptr<QueueHandle> QueueManager::GetQueueWithFlags(vk::QueueFlags flags, st
 	for(size_t i=0; i<m_queues.size(); i++)
 	{
 		//Skip if flags don't match
-		if(!(m_queues[i].Flags & flags))
+		if((m_queues[i].Flags & flags) != flags)
 			continue;
 
 		//If handle is unallocated, use it right away


### PR DESCRIPTION
Fixes https://github.com/glscopeclient/scopehal-apps/issues/597, where non-graphics queue would be selected for rendering.

This fixes the issue by requiring QueueManager check if the queue has all the requisite flags rather than some.