### PR TITLE
Correct ascending sort of Vulkan queues by feature flag count

### DIFF
--- a/scopehal/QueueManager.cpp
+++ b/scopehal/QueueManager.cpp
@@ -159,7 +159,7 @@ QueueManager::QueueManager(vk::raii::PhysicalDevice* phys, std::shared_ptr<vk::r
 				if(static_cast<uint32_t>(b.Flags) & (1<<i))
 					flag_count_b++;
 			}
-			return flag_count_a > flag_count_b;
+			return flag_count_a < flag_count_b;
 		});
 	LogDebug("Sorted queues:\n");
 	LogIndenter li;


### PR DESCRIPTION
This corrects Vulkan queue sort order from descending to ascending order of feature flag count. This is the intended sort behavior as stated in the sort comment.

This addresses the side effect from descending order sort, where QueueManager assigns a more featureful queue even though a more appropriate queue with fewer features is available. This side effect manifests on AMD integrated GPUs by assigning the only graphics-capable queue to g_vkTransferQueue (which only require Transfer capability) and rendering tasks.

For reference, we want to prioritize queues with the fewest features and reserve more general-purpose queues (with graphics capabilities) for graphics/rendering tasks. This works on the assumption that graphics-capable queues support more features.