### PR TITLE
Fix stale rigol channel enable states

### DIFF
--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -278,12 +278,16 @@ void RigolOscilloscope::EnableChannel(size_t i)
 {
 	lock_guard<recursive_mutex> lock(m_mutex);
 	m_transport->SendCommand(":" + m_channels[i]->GetHwname() + ":DISP ON");
+	// invalidate channel enable cache until confirmed on next IsChannelEnabled
+	m_channelsEnabled.erase(i);
 }
 
 void RigolOscilloscope::DisableChannel(size_t i)
 {
 	lock_guard<recursive_mutex> lock(m_mutex);
 	m_transport->SendCommand(":" + m_channels[i]->GetHwname() + ":DISP OFF");
+	// invalidate channel enable cache until confirmed on next IsChannelEnabled
+	m_channelsEnabled.erase(i);
 }
 
 vector<OscilloscopeChannel::CouplingType> RigolOscilloscope::GetAvailableCouplings(size_t /*i*/)


### PR DESCRIPTION
Fixes bug where channel enable list will never be updated after initial states are polled

Tested on Rigol MSO5074 with v00.01.03.03.00 FW, with full unlocks