### PR TITLE
Fixed overflow in Digilent RATES

### DIFF
--- a/scopehal/DigilentOscilloscope.cpp
+++ b/scopehal/DigilentOscilloscope.cpp
@@ -453,7 +453,7 @@ vector<uint64_t> DigilentOscilloscope::GetSampleRatesNonInterleaved()
 			break;
 
 		auto block = rates.substr(istart, i-istart);
-		auto fs = stol(block);
+		auto fs = stoll(block);
 		auto hz = FS_PER_SECOND / fs;
 		ret.push_back(hz);
 


### PR DESCRIPTION
`long` is not enough for femtoseconds